### PR TITLE
Fix shadowing of `lower_bound` and `upper_bound`, and pass the comparator

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -12298,7 +12298,7 @@ with \tcode{std::forward<Args>(args)...}.  If the set already contains an
 element whose key is equivalent to \tcode{t}, there is no effect.  Otherwise,
 equivalent to:
 \begin{codeblock}
-auto it = lower_bound(c.begin(), c.end(), t);
+auto it = std::lower_bound(c.begin(), c.end(), t, compare);
 c.emplace(it, std::move(t));
 \end{codeblock}
 
@@ -12951,7 +12951,7 @@ template <class... Args> iterator emplace(Args&&... args);
 First, constructs a \tcode{key_type} object \tcode{t} constructed
 with \tcode{std::forward<Args>(args)...}, then inserts \tcode{t} as if by:
 \begin{codeblock}
-auto it = upper_bound(c.begin(), c.end(), t);
+auto it = std::upper_bound(c.begin(), c.end(), t, compare);
 c.emplace(it, std::move(t));
 \end{codeblock}
 


### PR DESCRIPTION
I don't know what is the Standardese style here: normally an algorithm
in the `std` namespace would not be qualified, but here we have to do
something to distinguish the `std::lower_bound` algorithm from the
`flat_set::lower_bound` member function which in reality would hide the
name of the algorithm.

Separately, of course we need to pass `compare` here.

Notice that we do NOT pass `compare` to `std::lexicographical_compare`
in the definition of the comparison operators. This is a bit bizarre,
but it follows the precedent set by `std::set` and `std::map`.