### PR TITLE
Wording for `extract()` now specifies something not-broken for PMR containers

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10877,13 +10877,7 @@ containers extract() &&;
 \end{itemdecl}
 
 \begin{itemdescr}
-\effects Equivalent to:
-\begin{codeblock}
-containers temp;
-temp.keys.swap(c.keys);
-temp.values.swap(c.values);
-return temp;
-\end{codeblock}
+\effects Equivalent to \tcode{return std::move(c);}
 \end{itemdescr}
 
 \indexlibrarymember{flatmap}{replace}%
@@ -11698,13 +11692,7 @@ containers extract() &&;
 \end{itemdecl}
 
 \begin{itemdescr}
-\effects Equivalent to:
-\begin{codeblock}
-containers temp;
-temp.keys.swap(c.keys);
-temp.values.swap(c.values);
-return temp;
-\end{codeblock}
+\effects Equivalent to \tcode{return std::move(c);}
 \end{itemdescr}
 
 \indexlibrarymember{flatmultimap}{replace}%
@@ -12356,12 +12344,7 @@ container_type extract() &&;
 \end{itemdecl}
 
 \begin{itemdescr}
-\effects Equivalent to:
-\begin{codeblock}
-container_type temp;
-temp.swap(c);
-return temp;
-\end{codeblock}
+\effects Equivalent to \tcode{return std::move(c);}
 \end{itemdescr}
 
 \indexlibrarymember{flatset}{replace}%
@@ -13007,12 +12990,7 @@ container_type extract() &&;
 \end{itemdecl}
 
 \begin{itemdescr}
-\effects Equivalent to:
-\begin{codeblock}
-container_type temp;
-temp.swap(c);
-return temp;
-\end{codeblock}
+\effects Equivalent to \tcode{return std::move(c);}
 \end{itemdescr}
 
 \indexlibrarymember{flatmultiset}{replace}%


### PR DESCRIPTION
The old wording was in terms of "default-construct a KeyContainer `temp`,
then swap it with `c`." The swap will have undefined behavior whenever
`temp`'s default-constructed allocator is not equal to `c`'s allocator.
This is generally expected to be the case when KeyContainer is anything
with `std::pmr` in the name (e.g. `std::pmr::vector`).

    std::pmr::monotonic_buffer_resource mr;
    std::pmr::polymorphic_allocator<int> a(&mr);
    std::flat_set<int, std::less<>, std::pmr::vector<int>> fs({1, 2}, a);
    std::pmr::vector<int> v = std::move(fs).extract();
    assert(v.get_allocator() == a);