### PR TITLE
flat_map: Change || to && in allocator constraints

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10093,10 +10093,10 @@ namespace std {
       { }
     template <class Container>
       explicit flat_map(const Container& cont)
-        : flat_map(cont.begin(), cont.end(), key_compare()) { }
+        : flat_map(std::begin(cont), std::end(cont), key_compare()) { }
     template <class Container, class Alloc>
       flat_map(const Container& cont, const Alloc& a)
-        : flat_map(cont.begin(), cont.end(), key_compare(), a) { }
+        : flat_map(std::begin(cont), std::end(cont), key_compare(), a) { }
 
     flat_map(sorted_unique_t,
              key_container_type key_cont, mapped_container_type mapped_cont);
@@ -10108,10 +10108,10 @@ namespace std {
       { }
     template <class Container>
       flat_map(sorted_unique_t s, const Container& cont)
-        : flat_map(s, cont.begin(), cont.end(), key_compare()) { }
+        : flat_map(s, std::begin(cont), std::end(cont), key_compare()) { }
     template <class Container, class Alloc>
       flat_map(sorted_unique_t s, const Container& cont, const Alloc& a)
-        : flat_map(s, cont.begin(), cont.end(), key_compare(), a) { }
+        : flat_map(s, std::begin(cont), std::end(cont), key_compare(), a) { }
 
     explicit flat_map(const key_compare& comp)
       : c(containers()), compare(comp) { }
@@ -11116,10 +11116,10 @@ namespace std {
       { }
     template <class Container>
       explicit flat_multimap(const Container& cont)
-        : flat_multimap(cont.begin(), cont.end(), key_compare()) { }
+        : flat_multimap(std::begin(cont), std::end(cont), key_compare()) { }
     template <class Container, class Alloc>
       flat_multimap(const Container& cont, const Alloc& a)
-        : flat_multimap(cont.begin(), cont.end(), key_compare(), a) { }
+        : flat_multimap(std::begin(cont), std::end(cont), key_compare(), a) { }
 
     flat_multimap(sorted_equivalent_t,
                   key_container_type key_cont, mapped_container_type mapped_cont);
@@ -11131,10 +11131,10 @@ namespace std {
       { }
     template <class Container>
       flat_multimap(sorted_equivalent_t s, const Container& cont)
-        : flat_multimap(s, cont.begin(), cont.end(), key_compare()) { }
+        : flat_multimap(s, std::begin(cont), std::end(cont), key_compare()) { }
     template <class Container, class Alloc>
       flat_multimap(sorted_equivalent_t s, const Container& cont, const Alloc& a)
-        : flat_multimap(s, cont.begin(), cont.end(), key_compare(), a) { }
+        : flat_multimap(s, std::begin(cont), std::end(cont), key_compare(), a) { }
 
     explicit flat_multimap(const key_compare& comp)
       : c(containers()), compare(comp) { }
@@ -11894,13 +11894,13 @@ namespace std {
         : flat_set(container_type(std::move(key), a)) { }
     template <class Container>
       explicit flat_set(const Container& cont)
-        : flat_set(cont.begin(), cont.end(), key_compare()) { }
+        : flat_set(std::begin(cont), std::end(cont), key_compare()) { }
     template<class Container>
     flat_set(const Container& cont, const key_compare& comp)
         : flat_set(std::begin(cont), std::end(cont), comp) { }
     template <class Container, class Alloc>
       flat_set(const Container& cont, const Alloc& a)
-        : flat_set(cont.begin(), cont.end(), key_compare(), a) { }
+        : flat_set(std::begin(cont), std::end(cont), key_compare(), a) { }
     template <class Container, class Alloc>
       flat_set(const Container& cont, const key_compare& comp, const Alloc& a)
         : flat_set(std::begin(cont), std::end(cont), comp, a) { }
@@ -11912,13 +11912,13 @@ namespace std {
         : flat_set(s, key_container_type(std::move(key_cont), a)) { }
     template <class Container>
       flat_set(sorted_unique_t s, const Container& cont)
-        : flat_set(s, cont.begin(), cont.end(), key_compare()) { }
+        : flat_set(s, std::begin(cont), std::end(cont), key_compare()) { }
     template<class Container>
     flat_set(sorted_unique_t s, const Container& cont, const key_compare& comp)
         : flat_set(s, std::begin(cont), std::end(cont), comp) { }
     template <class Container, class Alloc>
       flat_set(sorted_unique_t s, const Container& cont, const Alloc& a)
-        : flat_set(s, cont.begin(), cont.end(), key_compare(), a) { }
+        : flat_set(s, std::begin(cont), std::end(cont), key_compare(), a) { }
     template<class Container, class Alloc>
     flat_set(sorted_unique_t s, const Container& cont, const key_compare& comp, const Alloc& a)
         : flat_set(s, std::begin(cont), std::end(cont), comp, a) { }
@@ -12555,13 +12555,13 @@ class flat_multiset {
         : flat_multiset(container_type(std::move(key), a)) { }
     template <class Container>
       explicit flat_multiset(const Container& cont)
-        : flat_multiset(cont.begin(), cont.end(), key_compare()) { }
+        : flat_multiset(std::begin(cont), std::end(cont), key_compare()) { }
     template<class Container>
     flat_multiset(const Container& cont, const key_compare& comp)
         : flat_multiset(std::begin(cont), std::end(cont), comp) { }
     template <class Container, class Alloc>
       flat_multiset(const Container& cont, const Alloc& a)
-        : flat_multiset(cont.begin(), cont.end(), key_compare(), a) { }
+        : flat_multiset(std::begin(cont), std::end(cont), key_compare(), a) { }
     template<class Container>
     flat_multiset(const Container& cont, const key_compare& comp, const Alloc& a)
         : flat_multiset(std::begin(cont), std::end(cont), comp, a) { }
@@ -12573,14 +12573,14 @@ class flat_multiset {
         : flat_multiset(s, container_type(std::move(cont), a)) { }
     template <class Container>
       flat_multiset(sorted_equivalent_t s, const Container& cont)
-        : flat_multiset(s, cont.begin(), cont.end(), key_compare()) { }
+        : flat_multiset(s, std::begin(cont), std::end(cont), key_compare()) { }
 
     template<class Container>
     flat_multiset(sorted_equivalent_t s, const Container& cont, const key_compare& comp)
         : flat_multiset(s, std::begin(cont), std::end(cont), comp) { }
     template <class Container, class Alloc>
       flat_multiset(sorted_equivalent_t s, const Container& cont, const Alloc& a)
-        : flat_multiset(s, cont.begin(), cont.end(), key_compare(), a) { }
+        : flat_multiset(s, std::begin(cont), std::end(cont), key_compare(), a) { }
     template<class Container>
     flat_multiset(sorted_equivalent_t s, const Container& cont, const key_compare& comp, const Alloc& a)
         : flat_multiset(s, std::begin(cont), std::end(cont), comp, a) { }

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10346,38 +10346,6 @@ namespace std {
   template<class Key, class T, class Alloc>
     flat_map(sorted_unique_t, initializer_list<pair<Key, T>>, Alloc)
       -> flat_map<Key, T, less<Key>, vector<Key>, vector<T>>;
-
-  template<class Key, class T, class Compare,
-           class KeyContainer, class MappedContainer>
-    bool operator==(const flat_map<Key, T, Compare, KeyContainer, MappedContainer>& x,
-                    const flat_map<Key, T, Compare, KeyContainer, MappedContainer>& y);
-  template<class Key, class T, class Compare,
-           class KeyContainer, class MappedContainer>
-    bool operator!=(const flat_map<Key, T, Compare, KeyContainer, MappedContainer>& x,
-                    const flat_map<Key, T, Compare, KeyContainer, MappedContainer>& y);
-  template<class Key, class T, class Compare,
-           class KeyContainer, class MappedContainer>
-    bool operator< (const flat_map<Key, T, Compare, KeyContainer, MappedContainer>& x,
-                    const flat_map<Key, T, Compare, KeyContainer, MappedContainer>& y);
-  template<class Key, class T, class Compare,
-           class KeyContainer, class MappedContainer>
-    bool operator> (const flat_map<Key, T, Compare, KeyContainer, MappedContainer>& x,
-                    const flat_map<Key, T, Compare, KeyContainer, MappedContainer>& y);
-  template<class Key, class T, class Compare,
-           class KeyContainer, class MappedContainer>
-    bool operator<=(const flat_map<Key, T, Compare, KeyContainer, MappedContainer>& x,
-                    const flat_map<Key, T, Compare, KeyContainer, MappedContainer>& y);
-  template<class Key, class T, class Compare,
-           class KeyContainer, class MappedContainer>
-    bool operator>=(const flat_map<Key, T, Compare, KeyContainer, MappedContainer>& x,
-                    const flat_map<Key, T, Compare, KeyContainer, MappedContainer>& y);
-
-  // specialized algorithms
-  template<class Key, class T, class Compare,
-           class KeyContainer, class MappedContainer>
-    void swap(flat_map<Key, T, Compare, KeyContainer, MappedContainer>& x,
-              flat_map<Key, T, Compare, KeyContainer, MappedContainer>& y)
-      noexcept(noexcept(x.swap(y)));
 }
 \end{codeblock}
 
@@ -11390,38 +11358,6 @@ namespace std {
   template<class Key, class T, class Alloc>
     flat_multimap(sorted_equivalent_t, initializer_list<pair<Key, T>>, Alloc)
       -> flat_multimap<Key, T, less<Key>, vector<Key>, vector<T>>;
-
-  template<class Key, class T, class Compare,
-           class KeyContainer, class MappedContainer>
-    bool operator==(const flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& x,
-                    const flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& y);
-  template<class Key, class T, class Compare,
-           class KeyContainer, class MappedContainer>
-    bool operator!=(const flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& x,
-                    const flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& y);
-  template<class Key, class T, class Compare,
-           class KeyContainer, class MappedContainer>
-    bool operator< (const flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& x,
-                    const flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& y);
-  template<class Key, class T, class Compare,
-           class KeyContainer, class MappedContainer>
-    bool operator> (const flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& x,
-                    const flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& y);
-  template<class Key, class T, class Compare,
-           class KeyContainer, class MappedContainer>
-    bool operator<=(const flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& x,
-                    const flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& y);
-  template<class Key, class T, class Compare,
-           class KeyContainer, class MappedContainer>
-    bool operator>=(const flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& x,
-                    const flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& y);
-
-  // specialized algorithms:
-  template<class Key, class T, class Compare,
-           class KeyContainer, class MappedContainer>
-    void swap(flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& x,
-              flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& y)
-      noexcept(noexcept(x.swap(y)));
 }
 \end{codeblock}
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10375,9 +10375,9 @@ flat_map(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
 \begin{itemdescr}
 \pnum
 \effects Initializes \tcode{c.keys} with
-\tcode{std::forward<key_container_type>(key_cont)} and \tcode{c.values} with
-\tcode{std::forward<mapped_container_type>(mapped_cont)}; sorts the range
-\range{begin()}{end()}.
+\tcode{std::move(key_cont)} and \tcode{c.values} with
+\tcode{std::move(mapped_cont)}; sorts the range
+\range{begin()}{end()} with \tcode{compare}.
 
 \pnum
 \complexity
@@ -10394,8 +10394,8 @@ flat_map(sorted_unique_t, key_container_type&& key_cont, mapped_container_type&&
 \begin{itemdescr}
 \pnum
 \effects Initializes \tcode{c.keys} with
-\tcode{std::forward<key_container_type>(key_cont)} and \tcode{c.values} with
-\tcode{std::forward<mapped_container_type>(mapped_cont)}.
+\tcode{std::move(key_cont)} and \tcode{c.values} with
+\tcode{std::move(mapped_cont)}.
 
 \pnum
 \complexity
@@ -10488,7 +10488,7 @@ for (; first != last; ++last) {
   c.values.insert(c.values.end(), first->second);
 }
 \end{codeblock}
-and finally sorts the range \range{begin()}{end()}.
+and finally sorts the range \range{begin()}{end()} with \tcode{compare}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{flatmap}!constructor}%
@@ -11387,9 +11387,9 @@ flat_multimap(key_container_type&& key_cont, mapped_container_type&& mapped_cont
 \begin{itemdescr}
 \pnum
 \effects Initializes \tcode{c.keys} with
-\tcode{std::forward<key_container_type>(key_cont)} and \tcode{c.values} with
-\tcode{std::forward<mapped_container_type>(mapped_cont)}; sorts the range
-+\range{begin()}{end()}.
+\tcode{std::move(key_cont)} and \tcode{c.values} with
+\tcode{std::move(mapped_cont)}; sorts the range
+\range{begin()}{end()} with \tcode{compare}.
 
 \pnum
 \complexity
@@ -11406,8 +11406,8 @@ flat_multimap(sorted_equivalent_t, key_container_type&& key_cont, mapped_contain
 \begin{itemdescr}
 \pnum
 \effects Initializes \tcode{c.keys} with
-\tcode{std::forward<key_container_type>(key_cont)} and \tcode{c.values} with
-\tcode{std::forward<mapped_container_type>(mapped_cont)}.
+\tcode{std::move(key_cont)} and \tcode{c.values} with
+\tcode{std::move(mapped_cont)}.
 
 \pnum
 \complexity
@@ -11487,7 +11487,7 @@ for (; first != last; ++last) {
   c.values.insert(c.values.end(), first->second);
 }
 \end{codeblock}
-and finally sorts the range \range{begin()}{end()}.
+and finally sorts the range \range{begin()}{end()} with \tcode{compare}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{flatmultimap}!constructor}%

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10314,27 +10314,27 @@ namespace std {
       -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>>;
 
   template<class Key, class T, class Compare = less<Key>>
-    flat_map(initializer_list<pair<const Key, T>>, Compare = Compare())
+    flat_map(initializer_list<pair<Key, T>>, Compare = Compare())
       -> flat_map<Key, T, Compare>;
 
   template<class Key, class T, class Compare, class Alloc>
-    flat_map(initializer_list<pair<const Key, T>>, Compare, Alloc)
+    flat_map(initializer_list<pair<Key, T>>, Compare, Alloc)
       -> flat_map<Key, T, Compare>;
 
   template<class Key, class T, class Alloc>
-    flat_map(initializer_list<pair<const Key, T>>, Alloc)
+    flat_map(initializer_list<pair<Key, T>>, Alloc)
       -> flat_map<Key, T>;
 
   template<class Key, class T, class Compare = less<Key>>
-  flat_map(sorted_unique_t, initializer_list<pair<const Key, T>>, Compare = Compare())
+  flat_map(sorted_unique_t, initializer_list<pair<Key, T>>, Compare = Compare())
       -> flat_map<Key, T, Compare>;
 
   template<class Key, class T, class Compare, class Alloc>
-    flat_map(sorted_unique_t, initializer_list<pair<const Key, T>>, Compare, Alloc)
+    flat_map(sorted_unique_t, initializer_list<pair<Key, T>>, Compare, Alloc)
       -> flat_map<Key, T, Compare>;
 
   template<class Key, class T, class Alloc>
-    flat_map(sorted_unique_t, initializer_list<pair<const Key, T>>, Alloc)
+    flat_map(sorted_unique_t, initializer_list<pair<Key, T>>, Alloc)
       -> flat_map<Key, T>;
 }
 \end{codeblock}
@@ -11318,28 +11318,28 @@ namespace std {
       -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>>;
 
   template<class Key, class T, class Compare = less<Key>>
-    flat_multimap(initializer_list<pair<const Key, T>>, Compare = Compare())
+    flat_multimap(initializer_list<pair<Key, T>>, Compare = Compare())
       -> flat_multimap<Key, T, Compare>;
 
   template<class Key, class T, class Compare, class Alloc>
-    flat_multimap(initializer_list<pair<const Key, T>>, Compare, Alloc)
+    flat_multimap(initializer_list<pair<Key, T>>, Compare, Alloc)
       -> flat_multimap<Key, T, Compare>;
 
   template<class Key, class T, class Alloc>
-    flat_multimap(initializer_list<pair<const Key, T>>, Alloc)
+    flat_multimap(initializer_list<pair<Key, T>>, Alloc)
       -> flat_multimap<Key, T>;
 
   template<class Key, class T, class Compare = less<Key>>
-  flat_multimap(sorted_equivalent_t, initializer_list<pair<const Key, T>>,
+  flat_multimap(sorted_equivalent_t, initializer_list<pair<Key, T>>,
                 Compare = Compare())
       -> flat_multimap<Key, T, Compare>;
 
   template<class Key, class T, class Compare, class Alloc>
-    flat_multimap(sorted_equivalent_t, initializer_list<pair<const Key, T>>, Compare, Alloc)
+    flat_multimap(sorted_equivalent_t, initializer_list<pair<Key, T>>, Compare, Alloc)
       -> flat_multimap<Key, T, Compare>;
 
   template<class Key, class T, class Alloc>
-    flat_multimap(sorted_equivalent_t, initializer_list<pair<const Key, T>>, Alloc)
+    flat_multimap(sorted_equivalent_t, initializer_list<pair<Key, T>>, Alloc)
       -> flat_multimap<Key, T>;
 }
 \end{codeblock}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10020,9 +10020,9 @@ namespace std {
       // \ref{flatmap.cons}, construct/copy/destroy
       flat_map();
 
-      flat_map(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
+      flat_map(key_container_type key_cont, mapped_container_type mapped_cont);
       template <class Alloc>
-      flat_map(key_container_type&& key_cont, mapped_container_type&& mapped_cont,
+      flat_map(key_container_type key_cont, mapped_container_type mapped_cont,
                const Alloc& a)
           : flat_map(key_container_type(std::move(key_cont), a),
                      mapped_container_type(std::move(mapped_cont), a))
@@ -10035,10 +10035,10 @@ namespace std {
           : flat_map(cont.begin(), cont.end(), key_compare(), a) { }
 
       flat_map(sorted_unique_t,
-               key_container_type&& key_cont, mapped_container_type&& mapped_cont);
+               key_container_type key_cont, mapped_container_type mapped_cont);
       template <class Alloc>
-      flat_map(sorted_unique_t s, key_container_type&& key_cont,
-               mapped_container_type&& mapped_cont, const Alloc& a)
+      flat_map(sorted_unique_t s, key_container_type key_cont,
+               mapped_container_type mapped_cont, const Alloc& a)
           : flat_map(s, key_container_type(std::move(key_cont), a),
                      mapped_container_type(std::move(mapped_cont), a))
         { }
@@ -10369,7 +10369,7 @@ namespace std {
 
 \indexlibrary{\idxcode{flatmap}!constructor}%
 \begin{itemdecl}
-flat_map(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
+flat_map(key_container_type key_cont, mapped_container_type mapped_cont);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10388,7 +10388,7 @@ is \tcode{key_cont.size()}.
 
 \indexlibrary{\idxcode{flatmap}!constructor}%
 \begin{itemdecl}
-flat_map(sorted_unique_t, key_container_type&& key_cont, mapped_container_type&& mapped_cont);
+flat_map(sorted_unique_t, key_container_type key_cont, mapped_container_type mapped_cont);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11079,9 +11079,9 @@ namespace std {
       // \ref{flatmultimap.cons}, construct/copy/destroy
       flat_multimap();
 
-      flat_multimap(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
+      flat_multimap(key_container_type key_cont, mapped_container_type mapped_cont);
       template <class Alloc>
-      flat_multimap(key_container_type&& key_cont, mapped_container_type&& mapped_cont,
+      flat_multimap(key_container_type key_cont, mapped_container_type mapped_cont,
                     const Alloc& a)
           : flat_multimap(key_container_type(std::move(key_cont), a),
                           mapped_container_type(std::move(mapped_cont), a))
@@ -11094,10 +11094,10 @@ namespace std {
           : flat_multimap(cont.begin(), cont.end(), key_compare(), a) { }
 
       flat_multimap(sorted_equivalent_t,
-                    key_container_type&& key_cont, mapped_container_type&& mapped_cont);
+                    key_container_type key_cont, mapped_container_type mapped_cont);
       template <class Alloc>
-      flat_multimap(sorted_equivalent_t, key_container_type&& key_cont,
-                    mapped_container_type&& mapped_cont, const Alloc& a)
+      flat_multimap(sorted_equivalent_t, key_container_type key_cont,
+                    mapped_container_type mapped_cont, const Alloc& a)
           : flat_multimap(key_container_type(std::move(key_cont), a),
                           mapped_container_type(std::move(mapped_cont), a))
         { }
@@ -11404,7 +11404,7 @@ namespace std {
 
 \indexlibrary{\idxcode{flatmultimap}!constructor}%
 \begin{itemdecl}
-flat_multimap(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
+flat_multimap(key_container_type key_cont, mapped_container_type mapped_cont);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11423,7 +11423,7 @@ is \tcode{key_cont.size()}.
 
 \indexlibrary{\idxcode{flatmultimap}!constructor}%
 \begin{itemdecl}
-flat_multimap(sorted_equivalent_t, key_container_type&& key_cont, mapped_container_type&& mapped_cont);
+flat_multimap(sorted_equivalent_t, key_container_type key_cont, mapped_container_type mapped_cont);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9950,6 +9950,31 @@ The template parameters \tcode{Key} and \tcode{T} of \tcode{flat_map} shall
 denote the same type as \tcode{KeyContainer::value_type}
 and \tcode{MappedContainer::value_type}, respectively.
 
+\pnum
+The effect of calling a constructor that takes both \tcode{key_container_type}
+and \tcode{mapped_container_type} arguments with containers of different sizes is
+undefined.
+
+\pnum
+Constructors that take a \tcode{Container} argument \tcode{cont} shall
+participate in overload resolution only if both \tcode{std::begin(cont)} and
+\tcode{std::end(cont)} are well-formed expressions.
+
+\pnum
+The effect of calling a constructor that takes a \tcode{sorted_unique_t}
+argument with a range that is not sorted with respect to \tcode{compare} is
+undefined.
+
+\pnum
+Constructors that take a \tcode{Alloc} argument shall participate in overload
+resolution only if \tcode{uses_allocator_v<key_container_type, Alloc> ||
+  uses_allocator_v<mapped_container_type, Alloc>} is \tcode{true}.
+
+\pnum
+Constructors that take an \tcode{Alloc} argument shall participate in overload
+resolution only if \tcode{Alloc} meets the allocator requirements as described
+in \iref{container.requirements.general}.
+
 \rSec3[flatmap.defn]{Definition}
 
 \begin{codeblock}
@@ -10342,22 +10367,6 @@ namespace std {
 
 \rSec3[flatmap.cons]{Constructors}
 
-\pnum
-The effect of calling a constructor that takes both \tcode{key_container_type}
-and \tcode{mapped_container_type} arguments with containers of different sizes is
-undefined.
-
-\pnum
-Constructors in this subclause that take a \tcode{Container}
-argument \tcode{cont} shall participate in overload resolution only if
-both \tcode{std::begin(cont)} and \tcode{std::end(cont)} are well-formed
-expressions.
-
-\pnum
-The effect of calling a constructor that takes a \tcode{sorted_unique_t}
-argument with a range that is not sorted with respect
-to \tcode{compare} is undefined.
-
 \indexlibrary{\idxcode{flatmap}!constructor}%
 \begin{itemdecl}
 flat_map(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
@@ -10430,22 +10439,6 @@ Linear.
 \end{itemdescr}
 
 \rSec3[flatmap.cons.alloc]{Constructors with allocators}
-
-\pnum
-If \tcode{uses_allocator_v<key_container_type, Alloc> \&\&
-uses_allocator_v<mapped_container_type, Alloc>} is \tcode{false} the
-constructors in this subclause shall not participate in overload resolution.
-
-\pnum
-Constructors in this subclause that take an \tcode{Alloc} argument shall
-participate in overload resolution only if \tcode{Alloc} meets the allocator
-requirements as described in \iref{container.requirements.general}.
-
-\pnum
-Constructors in this subclause that take a \tcode{Container}
-argument \tcode{cont} shall participate in overload resolution only if
-both \tcode{std::begin(cont)} and \tcode{std::end(cont)} are well-formed
-expressions.
 
 \indexlibrary{\idxcode{flatmap}!constructor}%
 \begin{itemdecl}
@@ -11021,6 +11014,32 @@ The template parameters \tcode{Key} and \tcode{T} of \tcode{flat_multimap}
 shall denote the same type as \tcode{KeyContainer::value_type}
 and \tcode{MappedContainer::value_type}, respectively.
 
+\pnum
+The effect of calling a constructor that takes both \tcode{key_container_type}
+and \tcode{mapped_container_type} arguments with containers of different sizes is
+undefined.
+
+\pnum
+Constructors in this subclause that take a \tcode{Container}
+argument \tcode{cont} shall participate in overload resolution only if
+both \tcode{std::begin(cont)} and \tcode{std::end(cont)} are well-formed
+expressions.
+
+\pnum
+The effect of calling a constructor that takes a \tcode{sorted_equivalent_t}
+argument with a container or containers that are not sorted with respect
+to \tcode{key_compare} is undefined.
+
+\pnum
+Constructors that take an \tcode{Alloc} argument shall participate in overload
+resolution only if \tcode{uses_allocator_v<key_container_type, Alloc> ||
+  uses_allocator_v<mapped_container_type, Alloc>} is \tcode{true}.
+
+\pnum
+Constructors that take an \tcode{Alloc} argument shall participate in overload
+resolution only if \tcode{Alloc} meets the allocator requirements as described
+in \iref{container.requirements.general}.
+
 \rSec3[flatmultimap.defn]{Definition}
 
 \begin{codeblock}
@@ -11389,22 +11408,6 @@ namespace std {
 
 \rSec3[flatmultimap.cons]{Constructors}
 
-\pnum
-The effect of calling a constructor that takes both \tcode{key_container_type}
-and \tcode{mapped_container_type} arguments with containers of different sizes is
-undefined.
-
-\pnum
-Constructors in this subclause that take a \tcode{Container}
-argument \tcode{cont} shall participate in overload resolution only if
-both \tcode{std::begin(cont)} and \tcode{std::end(cont)} are well-formed
-expressions.
-
-\pnum
-The effect of calling a constructor that takes a \tcode{sorted_equivalent_t}
-argument with a container or containers that are not sorted with respect
-to \tcode{key_compare} is undefined.
-
 \indexlibrary{\idxcode{flatmultimap}!constructor}%
 \begin{itemdecl}
 flat_multimap(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
@@ -11464,22 +11467,6 @@ Linear.
 \end{itemdescr}
 
 \rSec3[flatmultimap.cons.alloc]{Constructors with allocators}
-
-\pnum
-If \tcode{uses_allocator_v<key_container_type, Alloc> \&\&
-uses_allocator_v<mapped_container_type, Alloc>} is \tcode{false} the
-constructors in this subclause shall not participate in overload resolution.
-
-\pnum
-Constructors in this subclause that take an \tcode{Alloc} argument shall
-participate in overload resolution only if \tcode{Alloc} meets the allocator
-requirements as described in \iref{container.requirements.general}.
-
-\pnum
-Constructors in this subclause that take a \tcode{Container}
-argument \tcode{cont} shall participate in overload resolution only if
-both \tcode{std::begin(cont)} and \tcode{std::end(cont)} are well-formed
-expressions.
 
 \indexlibrary{\idxcode{flatmultimap}!constructor}%
 \begin{itemdecl}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10613,10 +10613,7 @@ template <class... Args> pair<iterator, bool> emplace(Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-The \tcode{pair<key_type, mapped_type>(std::forward<Args>(args)...)} is
-well-formed.
+\pnum \constraints \tcode{pair<key_type, mapped_type>(std::forward<Args>(args)...)} is well-formed.
 
 \pnum
 \effects
@@ -10645,17 +10642,13 @@ template<class P> iterator insert(const_iterator position, P&& x);
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum \constraints \tcode{pair<key_type, mapped_type>(std::forward<P>(x))} is well-formed.
+
 \pnum
 \effects
 The first form is equivalent to
 \tcode{return emplace(std::forward<P>(x))}. The second form is
 equivalent to \tcode{return emplace_hint(position, std::forward<P>(x))}.
-
-\pnum
-\remarks
-These signatures shall not participate in overload resolution
-unless \tcode{is_constructible_v<pair<key_type, mapped_type>, P>} is
-\tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{try_emplace}{flatmap}%
@@ -10667,10 +10660,7 @@ template<class... Args>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-The expression \tcode{mapped_type(std::forward<Args>(args)...)} is
-well-formed.
+\pnum \constraints \tcode{mapped_type(std::forward<Args>(args)...)} is well-formed.
 
 \pnum
 \effects
@@ -10704,10 +10694,7 @@ template<class... Args>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-The expression \tcode{mapped_type(std::forward<Args>(args)...)} is
-well-formed.
+\pnum \constraints \tcode{mapped_type(std::forward<Args>(args)...)} is well-formed.
 
 \pnum
 \effects
@@ -10743,16 +10730,13 @@ template<class M>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-\tcode{is_assignable_v<mapped_type\&, M>}, and the expresion
+\pnum \constraints \tcode{is_assignable_v<mapped_type\&, M>}, and
 \tcode{mapped_type(std::forward<M>(obj))} is well-formed.
 
 \pnum
 \effects
-If the map already contains an element \tcode{e}
-whose key is equivalent to \tcode{k},
-assigns \tcode{std::for\-ward<M>(obj)} to \tcode{e.second}.
+If the map already contains an element \tcode{e} whose key is equivalent
+to \tcode{k}, assigns \tcode{std::for\-ward<M>(obj)} to \tcode{e.second}.
 Otherwise equivalent to \tcode{insert(k, std::forward<M>(obj))} or
 \tcode{emplace(hint, k, std::forward<M>(obj))} respectively.
 
@@ -10821,14 +10805,13 @@ The range \range{first}{last} is sorted with respect to \tcode{compare}.
 \pnum \complexity Linear.
 \end{itemdescr}
 
-
 \indexlibrarymember{flatmap}{insert}%
 \begin{itemdecl}
 void insert(sorted_unique_t, initializer_list<value_type> il);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum Effects: Equivalent to \tcode{insert(sorted_unique_t{}, il.begin(), il.end())}.
+\pnum \effects Equivalent to \tcode{insert(sorted_unique_t{}, il.begin(), il.end())}.
 \end{itemdescr}
 
 \indexlibrarymember{flatmap}{swap}%
@@ -10837,21 +10820,17 @@ void swap(flat_map& fm) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum Effects: Equivalent to:
+\pnum \constraints \tcode{is_nothrow_swappable_v<key_container_type> \&\&
+is_nothrow_swappable_v<mapped_container_type> \&\&
+is_nothrow_swappable_v<key_compare>}
+
+\pnum \effects Equivalent to:
 \begin{codeblock}
 using std::swap;
 swap(c.keys, fm.c.keys);
 swap(c.values, fm.c.values);
 swap(c.compare, fm.compare);
 \end{codeblock}
-
-\pnum
-\remarks
-This function shall not participate in overload resolution
-unless \tcode{is_nothrow_swappable_v<key_container_type> \&\&
-is_nothrow_swappable_v<mapped_container_type> \&\&
-is_nothrow_swappable_v<key_compare>} is
-\tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{flatmap}{extract}%
@@ -10969,12 +10948,8 @@ template<class Key, class T, class Compare, class KeyContainer, class MappedCont
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\remarks
-This function shall not participate in overload resolution
-unless \tcode{is_nothrow_swappable_v<KeyContainer> \&\&
+\pnum \constraints \tcode{is_nothrow_swappable_v<KeyContainer> \&\&
 is_nothrow_swappable_v<MappedContainer> \&\& is_nothrow_swappable_v<Compare>}
-is \tcode{true}.
 
 \pnum
 \effects Equivalent to: \tcode{x.swap(y)}.
@@ -11625,17 +11600,14 @@ template <class... Args> pair<iterator, bool> emplace(Args&&... args);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\constraints
-The \tcode{pair<key_type, mapped_type>(std::forward<Args>(args)...)} is
-well-formed.
+\pnum \constraints \tcode{pair<key_type,
+mapped_type>(std::forward<Args>(args)...)} is well-formed.
 
 \pnum
 \effects
 First, constructs a \tcode{pair<key_type, value_type>} object \tcode{t}
-constructed with \tcode{std::forward<Args>(args)...}.  If the map already
-contains an element whose key is equivalent to the key of \tcode{t}, there is
-no effect.  Otherwise, equivalent to:
+constructed with \tcode{std::forward<Args>(args)...}, then inserts \tcode{t}
+as if by:
 \begin{codeblock}
 auto key_it = upper_bound(c.keys.begin(), c.keys.end(), t.first);
 auto value_it = c.values.begin() + distance(c.keys.begin(), key_it);
@@ -11645,9 +11617,7 @@ c.values.emplace(value_it, std::move(t.second));
 
 \pnum
 \returns
-The \tcode{bool} component of the returned pair is \tcode{true} if and only if
-the insertion took place, and the iterator component of the pair points to the
-element with key equivalent to the key of \tcode{t}.
+An iterator that points to the inserted element.
 \end{itemdescr}
 
 \indexlibrarymember{insert}{flatmultimap}%
@@ -11657,17 +11627,13 @@ template<class P> iterator insert(const_iterator position, P&& x);
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum \constraints \tcode{pair<key_type, mapped_type>(std::forward<P>(x))} is well-formed.
+
 \pnum
 \effects
 The first form is equivalent to
 \tcode{return emplace(std::forward<P>(x))}. The second form is
 equivalent to \tcode{return emplace_hint(position, std::forward<P>(x))}.
-
-\pnum
-\remarks
-These signatures shall not participate in overload resolution
-unless \tcode{is_constructible_v<pair<key_type, mapped_type>, P>} is
-\tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{flatmultimap}{insert}%
@@ -11691,7 +11657,7 @@ void insert(sorted_equivalent_t, initializer_list<value_type> il);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum Effects: Equivalent to \tcode{insert(sorted_equivalent_t{}, il.begin(), il.end())}.
+\pnum \effects Equivalent to \tcode{insert(sorted_equivalent_t{}, il.begin(), il.end())}.
 \end{itemdescr}
 
 \indexlibrarymember{flatmultimap}{swap}%
@@ -11700,21 +11666,17 @@ void swap(flat_multimap& fm) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum Effects: Equivalent to:
+\pnum \constraints \tcode{is_nothrow_swappable_v<key_container_type> \&\&
+is_nothrow_swappable_v<mapped_container_type> \&\&
+is_nothrow_swappable_v<key_compare>}
+
+\pnum \effects Equivalent to:
 \begin{codeblock}
 using std::swap;
 swap(c.keys, fm.c.keys);
 swap(c.values, fm.c.values);
 swap(c.compare, fm.compare);
 \end{codeblock}
-
-\pnum
-\remarks
-This function shall not participate in overload resolution
-unless \tcode{is_nothrow_swappable_v<key_container_type> \&\&
-is_nothrow_swappable_v<mapped_container_type> \&\&
-is_nothrow_swappable_v<key_compare>} is
-\tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{flatmultimap}{extract}%
@@ -11832,12 +11794,8 @@ template<class Key, class T, class Compare, class KeyContainer, class MappedCont
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\remarks
-This function shall not participate in overload resolution
-unless \tcode{is_nothrow_swappable_v<KeyContainer> \&\&
+\pnum \constraints \tcode{is_nothrow_swappable_v<KeyContainer> \&\&
 is_nothrow_swappable_v<MappedContainer> \&\& is_nothrow_swappable_v<Compare>}
-is \tcode{true}.
 
 \pnum
 \effects Equivalent to: \tcode{x.swap(y)}.

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10610,7 +10610,9 @@ template <class... Args> pair<iterator, bool> emplace(Args&&... args);
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{value_type} shall be \tcode{EmplaceConstructible} into \tcode{map} from \tcode{args}.
+\tcode{value_type} shall be contructible from \tcode{args...}, so that the
+following expression is well-formed: \tcode{pair<key_type,
+  mapped_type>(std::forward<Args>(args)...)}.
 
 \pnum
 \effects
@@ -10663,9 +10665,9 @@ template<class... Args>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{key_type} shall be \tcode{CopyInsertable} into \tcode{key_container_type}, and
-\tcode{mapped_type} shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
-from \tcode{args...}.
+\tcode{mapped_type} shall be contructible from \tcode{args...}, so that the
+following expression is well-formed:
+\tcode{mapped_type(std::forward<Args>(args)...)}.
 
 \pnum
 \effects
@@ -10701,9 +10703,9 @@ template<class... Args>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{key_type} shall be \tcode{MoveInsertable} into \tcode{key_container_type}, and
-\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
-from \tcode{args...}.
+\tcode{mapped_type} shall be contructible from \tcode{args...}, so that the
+following expression is well-formed:
+\tcode{mapped_type(std::forward<Args>(args)...)}.
 
 \pnum
 \effects
@@ -10742,9 +10744,9 @@ template<class M>
 \pnum
 \requires
 \tcode{is_assignable_v<mapped_type\&, M>} shall be \tcode{true}.
-\tcode{key_type} shall be \tcode{CopyInsertable} into \tcode{key_container_type}, and
-\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
-from \tcode{obj}.
+\tcode{mapped_type} shall be contructible from \tcode{obj}, so that the
+following expression is well-formed:
+\tcode{mapped_type(std::forward<Args>(obj))}.
 
 \pnum
 \effects
@@ -10780,9 +10782,9 @@ template<class M>
 \pnum
 \requires
 \tcode{is_assignable_v<mapped_type\&, M>} shall be \tcode{true}.
-\tcode{key_type} shall be \tcode{MoveInsertable} into \tcode{key_container_type}, and
-\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
-from \tcode{obj}.
+\tcode{mapped_type} shall be contructible from \tcode{obj}, so that the
+following expression is well-formed:
+\tcode{mapped_type(std::forward<Args>(obj))}.
 
 \pnum
 \effects
@@ -11584,7 +11586,9 @@ template <class... Args> pair<iterator, bool> emplace(Args&&... args);
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{value_type} shall be \tcode{EmplaceConstructible} into \tcode{map} from \tcode{args}.
+\tcode{value_type} shall be contructible from \tcode{args...}, so that the
+following expression is well-formed:
+\tcode{value_type(std::forward<Args>(args)...)}.
 
 \pnum
 \effects
@@ -11661,9 +11665,9 @@ template<class... Args>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{key_type} shall be \tcode{CopyInsertable} into \tcode{key_container_type}, and
-\tcode{mapped_type} shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
-from \tcode{args...}.
+\tcode{mapped_type} shall be contructible from \tcode{args...}, so that the
+following expression is well-formed:
+\tcode{mapped_type(std::forward<Args>(args)...)}.
 
 \pnum
 \effects
@@ -11699,9 +11703,9 @@ template<class... Args>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{key_type} shall be \tcode{MoveInsertable} into \tcode{key_container_type}, and
-\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
-from \tcode{args...}.
+\tcode{mapped_type} shall be contructible from \tcode{args...}, so that the
+following expression is well-formed:
+\tcode{mapped_type(std::forward<Args>(args)...)}.
 
 \pnum
 \effects

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10525,7 +10525,7 @@ Linear.
 
 \rSec3[flatmap.capacity]{Capacity}
 
-\indexlibrary{\idxcode{max_size}!\idxcode{flatmap}}%
+\indexlibrarymember{size}{flatmap}%
 \begin{itemdecl}
 size_type size() const noexcept;
 \end{itemdecl}
@@ -10536,7 +10536,7 @@ size_type size() const noexcept;
 Equivalent to: \tcode{return c.keys.size();}
 \end{itemdescr}
 
-\indexlibrary{\idxcode{max_size}!\idxcode{flatmap}}%
+\indexlibrarymember{max_size}{flatmap}%
 \begin{itemdecl}
 size_type max_size() const noexcept;
 \end{itemdecl}
@@ -11141,7 +11141,7 @@ namespace std {
                     const key_compare& comp = key_compare());
     template <class InputIterator, class Alloc>
       flat_multimap(InputIterator first, InputIterator last,
-                   const key_compare& comp, const Alloc& a);
+                    const key_compare& comp, const Alloc& a);
     template <class InputIterator, class Alloc>
       flat_multimap(InputIterator first, InputIterator last,
                     const Alloc& a)
@@ -11444,7 +11444,8 @@ is \tcode{key_cont.size()}.
 
 \indexlibrary{\idxcode{flatmultimap}!constructor}%
 \begin{itemdecl}
-flat_multimap(sorted_equivalent_t, key_container_type key_cont, mapped_container_type mapped_cont);
+flat_multimap(sorted_equivalent_t, key_container_type key_cont,
+              mapped_container_type mapped_cont);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11492,8 +11493,8 @@ template <class InputIterator>
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{compare} with
-\tcode{comp}, and adds elements to \tcode{c.keys} and \tcode{c.values} as if by:
+\effects Initializes \tcode{compare} with \tcode{comp}, and adds elements to
+\tcode{c.keys} and \tcode{c.values} as if by:
 \begin{codeblock}
 for (; first != last; ++first) {
   c.keys.insert(c.keys.end(), first->first);
@@ -11519,6 +11520,10 @@ template <class Alloc>
 \effects Initializes \tcode{compare} with \tcode{comp}, and performs
 uses-allocator construction\iref{allocator.uses.construction} of both
 \tcode{c.keys} and \tcode{c.values} with \tcode{a}.
+
+\pnum
+\complexity
+Constant.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{flatmultimap}!constructor}%
@@ -11546,7 +11551,7 @@ and finally sorts the range \range{begin()}{end()} with \tcode{compare}.
 \complexity
 Linear in $N$ if the container arguments are already sorted as if with
 \tcode{compare} and otherwise $N \log N$, where $N$ is
-\tcode{key_cont.size()}.
+\tcode{distance(first, last)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{flatmultimap}!constructor}%
@@ -11574,15 +11579,38 @@ for (; first != last; ++first) {
 Linear.
 \end{itemdescr}
 
-\rSec3[flatmultimap.modifiers]{Modifiers}
+\rSec3[flatmultimap.capacity]{Capacity}
 
-\indexlibrarymember{operator=}{flatmap}%
+\indexlibrarymember{size}{flatmultimap}%
 \begin{itemdecl}
-flat_map& operator=(initializer_list<value_type> il);
+size_type size() const noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return c.keys.size();}
+\end{itemdescr}
 
+\indexlibrarymember{max_size}{flatmultimap}%
+\begin{itemdecl}
+size_type max_size() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return std::min<size_type>(c.keys.max_size(), c.values.max_size());}
+\end{itemdescr}
+
+\rSec3[flatmultimap.modifiers]{Modifiers}
+
+\indexlibrarymember{operator=}{flatmultimap}%
+\begin{itemdecl}
+flat_multimap& operator=(initializer_list<value_type> il);
+\end{itemdecl}
+
+\begin{itemdescr}
 \pnum
 \effects Equivalent to:
 \begin{codeblock}
@@ -11599,7 +11627,8 @@ template <class... Args> pair<iterator, bool> emplace(Args&&... args);
 \begin{itemdescr}
 \pnum
 \constraints
-The expression \tcode{value_type(std::forward<Args>(args)...)} is well-formed.
+The \tcode{pair<key_type, mapped_type>(std::forward<Args>(args)...)} is
+well-formed.
 
 \pnum
 \effects
@@ -11658,87 +11687,11 @@ The range \range{first}{last} is sorted with respect to \tcode{compare}.
 
 \indexlibrarymember{flatmultimap}{insert}%
 \begin{itemdecl}
-void insert(sorted_unique_t, initializer_list<value_type> il);
+void insert(sorted_equivalent_t, initializer_list<value_type> il);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum Effects: Equivalent to \tcode{insert(sorted_unique_t{}, il.begin(), il.end())}.
-\end{itemdescr}
-
-\indexlibrarymember{try_emplace}{flatmultimap}%
-\begin{itemdecl}
-template<class... Args>
-  pair<iterator, bool> try_emplace(const key_type& k, Args&&... args);
-template<class... Args>
-  iterator try_emplace(const_iterator hint, const key_type& k, Args&&... args);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\constraints
-The expression \tcode{mapped_type(std::forward<Args>(args)...)} is
-well-formed.
-
-\pnum
-\effects
-If the map already contains an element whose key is equivalent to \tcode{k},
-there is no effect.  Otherwise equivalent to:
-\begin{codeblock}
-auto key_it = upper_bound(c.keys.begin(), c.keys.end(), k);
-auto value_it = c.values.begin() + distance(c.keys.begin(), key_it);
-c.keys.insert(key_it, k);
-c.values.emplace(value_it, std::forward<Args>(args)...);
-\end{codeblock}
-
-\pnum
-\returns
-In the first overload, the \tcode{bool} component of the returned pair
-is \tcode{true} if and only if the insertion took place.  The returned
-iterator points to the map element whose key is equivalent to \tcode{k}.
-
-\pnum
-\complexity
-The same as \tcode{emplace} and \tcode{emplace_hint},
-respectively.
-\end{itemdescr}
-
-\indexlibrarymember{try_emplace}{flatmultimap}%
-\begin{itemdecl}
-template<class... Args>
-  pair<iterator, bool> try_emplace(key_type&& k, Args&&... args);
-template<class... Args>
-  iterator try_emplace(const_iterator hint, key_type&& k, Args&&... args);
-\end{itemdecl}
-
-\begin{itemdescr}
-\pnum
-\constraints
-The expression \tcode{mapped_type(std::forward<Args>(args)...)} is
-well-formed.
-
-\pnum
-\effects
-If the map already contains an element whose key is equivalent to \tcode{k},
-there is no effect.  Otherwise equivalent to:
-\begin{codeblock}
-auto key_it = upper_bound(c.keys.begin(), c.keys.end(), k);
-auto value_it = c.values.begin() + distance(c.keys.begin(), key_it);
-c.keys.emplace(key_it, std::move(k));
-c.values.emplace(value_it, std::forward<Args>(args)...);
-\end{codeblock}
-
-\pnum
-\returns
-In the first overload,
-the \tcode{bool} component of the returned pair is \tcode{true}
-if and only if the insertion took place.
-The returned iterator points to the map element
-whose key is equivalent to \tcode{k}.
-
-\pnum
-\complexity
-The same as \tcode{emplace} and \tcode{emplace_hint},
-respectively.
+\pnum Effects: Equivalent to \tcode{insert(sorted_equivalent_t{}, il.begin(), il.end())}.
 \end{itemdescr}
 
 \indexlibrarymember{flatmultimap}{swap}%

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9962,8 +9962,8 @@ participate in overload resolution only if both \tcode{std::begin(cont)} and
 
 \pnum
 The effect of calling a constructor that takes a \tcode{sorted_unique_t}
-argument with a range that is not sorted with respect to \tcode{compare} is
-undefined.
+argument with a range that is not sorted with respect to \tcode{compare}, or
+that contains equal elements, is undefined.
 
 \pnum
 Constructors that take an \tcode{Alloc} argument shall participate in overload

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10080,15 +10080,15 @@ namespace std {
 
       template <class Alloc>
         flat_map(flat_map&& m, const Alloc& a)
-          : compare{std::move(m.compare)}
-          , c{key_container_type(std::move(m.c.keys), a),
+          : c{key_container_type(std::move(m.c.keys), a),
               mapped_container_type(std::move(m.c.values), a)}
+          , compare{std::move(m.compare)}
         { }
       template<class Alloc>
         flat_map(const flat_map& m, const Alloc& a)
-          : compare{m.compare}
-          , c{key_container_type(m.c.keys, a),
+          : c{key_container_type(m.c.keys, a),
               mapped_container_type(m.c.values, a)}
+          , compare{m.compare}
         { }
 
       flat_map(initializer_list<value_type>&& il,
@@ -11139,14 +11139,14 @@ namespace std {
 
       template <class Alloc>
         flat_multimap(flat_multimap&& m, const Alloc& a)
-          : compare{std::move(m.compare)}
-          , c{key_container_type(std::move(m.c.keys), a),
+          : c{key_container_type(std::move(m.c.keys), a),
               mapped_container_type(std::move(m.c.values), a)}
+          , compare{std::move(m.compare)}
         { }
       template<class Alloc>
         flat_multimap(const flat_multimap& m, const Alloc& a)
-          : compare{m.compare}
-          , c{key_container_type(m.c.keys, a), mapped_container_type(m.c.values, a)}
+          : c{key_container_type(m.c.keys, a), mapped_container_type(m.c.values, a)}
+          , compare{m.compare}
         { }
 
       flat_multimap(initializer_list<value_type>&& il,

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10704,7 +10704,7 @@ template<class M>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \constraints \tcode{is_assignable_v<mapped_type\&, M>}, and
+\pnum \constraints \tcode{is_assignable_v<mapped_type\&, M>} is \tcode{true}, and
 \tcode{mapped_type(std::forward<M>(obj))} is well-formed.
 
 \pnum
@@ -10739,7 +10739,7 @@ template<class M>
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{is_assignable_v<mapped_type\&, M>}, and the expression
+\tcode{is_assignable_v<mapped_type\&, M>} is \tcode{true}, and the expression
 \tcode{mapped_type(std::forward<M>(obj))} is well-formed.
 
 \pnum
@@ -10796,7 +10796,7 @@ void swap(flat_map& fm) noexcept;
 \begin{itemdescr}
 \pnum \constraints \tcode{is_nothrow_swappable_v<key_container_type> \&\&
 is_nothrow_swappable_v<mapped_container_type> \&\&
-is_nothrow_swappable_v<key_compare>}
+is_nothrow_swappable_v<key_compare>} is \tcode{true}.
 
 \pnum \effects Equivalent to:
 \begin{codeblock}
@@ -10829,7 +10829,7 @@ void replace(key_container_type&& key_cont, mapped_container_type&& mapped_cont)
 
 \begin{itemdescr}
 \pnum \expects
-\tcode{key_cont.size() == mapped_cont.size()}, and the elements of
+\tcode{key_cont.size() == mapped_cont.size()} is \tcode{true}, and the elements of
 \tcode{key_cont} are sorted with respect to \tcode{compare}.
 
 \pnum
@@ -10924,6 +10924,7 @@ template<class Key, class T, class Compare, class KeyContainer, class MappedCont
 \begin{itemdescr}
 \pnum \constraints \tcode{is_nothrow_swappable_v<KeyContainer> \&\&
 is_nothrow_swappable_v<MappedContainer> \&\& is_nothrow_swappable_v<Compare>}
+is \tcode{true}.
 
 \pnum
 \effects Equivalent to: \tcode{x.swap(y)}.
@@ -11616,7 +11617,7 @@ void swap(flat_multimap& fm) noexcept;
 \begin{itemdescr}
 \pnum \constraints \tcode{is_nothrow_swappable_v<key_container_type> \&\&
 is_nothrow_swappable_v<mapped_container_type> \&\&
-is_nothrow_swappable_v<key_compare>}
+is_nothrow_swappable_v<key_compare>} is \tcode{true}.
 
 \pnum \effects Equivalent to:
 \begin{codeblock}
@@ -11649,7 +11650,7 @@ void replace(key_container_type&& key_cont, mapped_container_type&& mapped_cont)
 
 \begin{itemdescr}
 \pnum \expects
-\tcode{key_cont.size() == mapped_cont.size()}, and the elements of
+\tcode{key_cont.size() == mapped_cont.size()} is \tcode{true}, and the elements of
 \tcode{key_cont} are sorted with respect to \tcode{compare}.
 
 \pnum
@@ -11744,6 +11745,7 @@ template<class Key, class T, class Compare, class KeyContainer, class MappedCont
 \begin{itemdescr}
 \pnum \constraints \tcode{is_nothrow_swappable_v<KeyContainer> \&\&
 is_nothrow_swappable_v<MappedContainer> \&\& is_nothrow_swappable_v<Compare>}
+is \tcode{true}.
 
 \pnum
 \effects Equivalent to: \tcode{x.swap(y)}.

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -11081,8 +11081,8 @@ namespace std {
       template <class Alloc>
       flat_multimap(key_container_type&& key_cont, mapped_container_type&& mapped_cont,
                     const Alloc& a)
-          : flat_map(key_container_type(std::move(key_cont), a),
-                     mapped_container_type(std::move(mapped_cont), a))
+          : flat_multimap(key_container_type(std::move(key_cont), a),
+                          mapped_container_type(std::move(mapped_cont), a))
         { }
       template <class Container>
         explicit flat_multimap(const Container& cont)
@@ -11096,8 +11096,8 @@ namespace std {
       template <class Alloc>
       flat_multimap(sorted_equivalent_t, key_container_type&& key_cont,
                     mapped_container_type&& mapped_cont, const Alloc& a)
-          : flat_map(key_container_type(std::move(key_cont), a),
-                     mapped_container_type(std::move(mapped_cont), a))
+          : flat_multimap(key_container_type(std::move(key_cont), a),
+                          mapped_container_type(std::move(mapped_cont), a))
         { }
       template <class Container>
         flat_multimap(sorted_equivalent_t s, const Container& cont)

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -8923,7 +8923,7 @@ adaptor's \tcode{Container}, \tcode{KeyContainer}, \tcode{MappedContainer}, or
 \pnum
 For container adaptors that have them, the \tcode{insert}, \tcode{emplace},
 and \tcode{erase} members shall affect the validity of iterators and
-references to the adaptor's container(s) in the same way that the containers'
+references to the adaptor's container(s) in the same ways that the containers'
 respective \tcode{insert}, \tcode{emplace}, and \tcode{erase} members do.
 \begin{example}
 A call to \tcode{flat_map<Key, T>::insert} invalidates all iterators to
@@ -9929,16 +9929,15 @@ a \tcode{flat_map<Key,T>} the \tcode{key_type} is \tcode{Key} and the
 \tcode{value_type} is \tcode{pair<const Key,T>}.
 
 \pnum
-A \tcode{flat_map} \tcode{m} maintains these invariants: it contains the same
-number of keys and values; the keys are sorted with respect to the
-comparison object; and the value at offset \tcode{o} within the value
-container is the value associated with the key at offset \tcode{o} within the
-key container.
-
-\pnum
 Descriptions are provided here only for operations on \tcode{flat_map} that
 are not described in one of those tables or for operations where there is
 additional semantic information.
+
+\pnum
+A \tcode{flat_map} maintains the following invariants: it contains the same
+number of keys and values; the keys are sorted with respect to the comparison
+object; and the value at offset \tcode{o} within the value container is the
+value associated with the key at offset \tcode{o} within the key container.
 
 \pnum
 Any sequence container supporting random access iteration can be used to
@@ -10739,7 +10738,7 @@ template<class M>
 \begin{itemdescr}
 \pnum
 \constraints
-\tcode{is_assignable_v<mapped_type\&, M>} is \tcode{true}, and the expression
+\tcode{is_assignable_v<mapped_type\&, M>} is \tcode{true}, and
 \tcode{mapped_type(std::forward<M>(obj))} is well-formed.
 
 \pnum
@@ -10958,16 +10957,16 @@ a \tcode{flat_multimap<Key,T>} the \tcode{key_type} is \tcode{Key} and the
 \tcode{value_type} is \tcode{pair<const Key,T>}.
 
 \pnum
-A \tcode{flat_multimap} \tcode{m} maintains these invariants: it contains the
+Descriptions are provided here only for operations on \tcode{flat_multimap}
+that are not described in one of those tables or for operations where
+there is additional semantic information.
+
+\pnum
+A \tcode{flat_multimap} maintains the following invariants: it contains the
 same number of keys and values; the keys are sorted with respect to the
 comparison object; and the value at offset \tcode{o} within the value
 container is the value associated with the key at offset \tcode{o} within the
 key container.
-
-\pnum
-Descriptions are provided here only for operations on \tcode{flat_multimap}
-that are not described in one of those tables or for operations where
-there is additional semantic information.
 
 \pnum
 Any sequence container supporting random access iteration can be used to

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10485,9 +10485,9 @@ uses_allocator_v<mapped_container_type, Alloc>} is \tcode{false} the
 constructors in this subclause shall not participate in overload resolution.
 
 \pnum
-Constructors in this subclause that take an \tcode{Allocator} argument shall
-participate in overload resolution only if \tcode{Allocator} meets the
-allocator requirements as described in \iref{container.requirements.general}.
+Constructors in this subclause that take an \tcode{Alloc} argument shall
+participate in overload resolution only if \tcode{Alloc} meets the allocator
+requirements as described in \iref{container.requirements.general}.
 
 \pnum
 Constructors in this subclause that take a \tcode{Container}
@@ -11523,9 +11523,9 @@ uses_allocator_v<mapped_container_type, Alloc>} is \tcode{false} the
 constructors in this subclause shall not participate in overload resolution.
 
 \pnum
-Constructors in this subclause that take an \tcode{Allocator} argument shall
-participate in overload resolution only if \tcode{Allocator} meets the
-allocator requirements as described in \iref{container.requirements.general}.
+Constructors in this subclause that take an \tcode{Alloc} argument shall
+participate in overload resolution only if \tcode{Alloc} meets the allocator
+requirements as described in \iref{container.requirements.general}.
 
 \pnum
 Constructors in this subclause that take a \tcode{Container}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -11891,7 +11891,7 @@ namespace std {
     explicit flat_set(container_type);
     template <class Alloc>
       flat_set(container_type cont, const Alloc& a)
-        : flat_set(container_type(std::move(key), a)) { }
+        : flat_set(container_type(std::move(cont), a)) { }
     template <class Container>
       explicit flat_set(const Container& cont)
         : flat_set(std::begin(cont), std::end(cont), key_compare()) { }
@@ -11909,7 +11909,7 @@ namespace std {
       : c(std::move(cont)), compare(key_compare()) { }
     template <class Alloc>
       flat_set(sorted_unique_t s, container_type cont, const Alloc& a)
-        : flat_set(s, key_container_type(std::move(key_cont), a)) { }
+        : flat_set(s, container_type(std::move(cont), a)) { }
     template <class Container>
       flat_set(sorted_unique_t s, const Container& cont)
         : flat_set(s, std::begin(cont), std::end(cont), key_compare()) { }
@@ -11928,7 +11928,7 @@ namespace std {
     template <class Alloc>
       flat_set(const key_compare& comp, const Alloc&);
     template <class Alloc>
-      explicit flat_set(const Alloc&) 
+      explicit flat_set(const Alloc& a)
         : flat_set(key_compare(), a) { }
 
     template <class InputIterator>
@@ -11977,7 +11977,7 @@ namespace std {
 
     flat_set(sorted_unique_t s, initializer_list<key_type>&& il,
              const key_compare& comp = key_compare()) 
-        : flat_set(s ,il, comp) { }
+        : flat_set(s, il, comp) { }
     template <class Alloc>
       flat_set(sorted_unique_t s, initializer_list<key_type>&& il,
                const key_compare& comp, const Alloc& a) 
@@ -12078,7 +12078,7 @@ namespace std {
     using @\placeholder{cont-value-type}@ = typename Container::value_type; // \expos
   template<class InputIterator>
     using @\placeholder{iter-value-type}@ = remove_const_t<
-      typename iterator_traits<InputIterator>::value_type::first_type>;     // \expos
+      typename iterator_traits<InputIterator>::value_type>;     // \expos
 
   template <class Container>
     flat_set(Container)
@@ -12552,7 +12552,7 @@ class flat_multiset {
     explicit flat_multiset(container_type cont);
     template <class Alloc>
       flat_multiset(container_type cont, const Alloc& a)
-        : flat_multiset(container_type(std::move(key), a)) { }
+        : flat_multiset(container_type(std::move(cont), a)) { }
     template <class Container>
       explicit flat_multiset(const Container& cont)
         : flat_multiset(std::begin(cont), std::end(cont), key_compare()) { }
@@ -12741,7 +12741,7 @@ class flat_multiset {
     using @\placeholder{cont-value-type}@ = typename Container::value_type; // \expos
   template<class InputIterator>
     using @\placeholder{iter-value-type}@ = remove_const_t<
-      typename iterator_traits<InputIterator>::value_type::first_type>;     // \expos
+      typename iterator_traits<InputIterator>::value_type>;     // \expos
 
   template <class Container>
     flat_multiset(Container)

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -11867,7 +11867,7 @@ in \iref{container.requirements.general}.
 
 \begin{codeblock}
 namespace std {
-  template <class Key, class Compare = less<Key>, class Container = vector<Key>>
+  template <class Key, class Compare = less<Key>, class KeyContainer = vector<Key>>
   class flat_set {
   public:
     // types:
@@ -11883,7 +11883,7 @@ namespace std {
     using const_iterator            = @\impdefx{type of \tcode{flat_set::const_iterator}}@; // see \ref{container.requirements}
     using reverse_iterator          = std::reverse_iterator<iterator>;
     using const_reverse_iterator    = std::reverse_iterator<const_iterator>;
-    using container_type            = Container;
+    using container_type            = KeyContainer;
 
     // \ref{flatset.cons}, construct/copy/destroy
     flat_set() : flat_set(key_compare()) { }
@@ -12379,9 +12379,9 @@ c = std::move(cont);
 
 \indexlibrary{\idxcode{operator==}!\idxcode{flatset}}%
 \begin{itemdecl}
-template<class Key, class Compare, class Container>
-  bool operator==(const flat_set<Key, Compare, Container>& x,
-                  const flat_set<Key, Compare, Container>& y);
+template<class Key, class Compare, class KeyContainer>
+  bool operator==(const flat_set<Key, Compare, KeyContainer>& x,
+                  const flat_set<Key, Compare, KeyContainer>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12392,9 +12392,9 @@ template<class Key, class Compare, class Container>
 
 \indexlibrary{\idxcode{operator!=}!\idxcode{flatset}}%
 \begin{itemdecl}
-template<class Key, class Compare, class Container>
-  bool operator!=(const flat_set<Key, Compare, Container>& x,
-                  const flat_set<Key, Compare, Container>& y);
+template<class Key, class Compare, class KeyContainer>
+  bool operator!=(const flat_set<Key, Compare, KeyContainer>& x,
+                  const flat_set<Key, Compare, KeyContainer>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12403,9 +12403,9 @@ template<class Key, class Compare, class Container>
 
 \indexlibrary{\idxcode{operator<}!\idxcode{flatset}}%
 \begin{itemdecl}
-template<class Key, class Compare, class Container>
-  bool operator< (const flat_set<Key, Compare, Container>& x,
-                  const flat_set<Key, Compare, Container>& y);
+template<class Key, class Compare, class KeyContainer>
+  bool operator< (const flat_set<Key, Compare, KeyContainer>& x,
+                  const flat_set<Key, Compare, KeyContainer>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12416,9 +12416,9 @@ template<class Key, class Compare, class Container>
 
 \indexlibrary{\idxcode{operator>}!\idxcode{flatset}}%
 \begin{itemdecl}
-template<class Key, class Compare, class Container>
-  bool operator> (const flat_set<Key, Compare, Container>& x,
-                  const flat_set<Key, Compare, Container>& y);
+template<class Key, class Compare, class KeyContainer>
+  bool operator> (const flat_set<Key, Compare, KeyContainer>& x,
+                  const flat_set<Key, Compare, KeyContainer>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12427,9 +12427,9 @@ template<class Key, class Compare, class Container>
 
 \indexlibrary{\idxcode{operator<=}!\idxcode{flatset}}%
 \begin{itemdecl}
-template<class Key, class Compare, class Container>
-  bool operator<=(const flat_set<Key, Compare, Container>& x,
-                  const flat_set<Key, Compare, Container>& y);
+template<class Key, class Compare, class KeyContainer>
+  bool operator<=(const flat_set<Key, Compare, KeyContainer>& x,
+                  const flat_set<Key, Compare, KeyContainer>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12438,9 +12438,9 @@ template<class Key, class Compare, class Container>
 
 \indexlibrary{\idxcode{operator>=}!\idxcode{flatset}}%
 \begin{itemdecl}
-template<class Key, class Compare, class Container>
-  bool operator>=(const flat_set<Key, Compare, Container>& x,
-                  const flat_set<Key, Compare, Container>& y);
+template<class Key, class Compare, class KeyContainer>
+  bool operator>=(const flat_set<Key, Compare, KeyContainer>& x,
+                  const flat_set<Key, Compare, KeyContainer>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -12451,13 +12451,13 @@ template<class Key, class Compare, class Container>
 
 \indexlibrarymember{swap}{flatset}%
 \begin{itemdecl}
-template<class Key, class Compare, class Container>
-  void swap(flat_set<Key, Compare, Container>& x,
-            flat_set<Key, Compare, Container>& y) noexcept;
+template<class Key, class Compare, class KeyContainer>
+  void swap(flat_set<Key, Compare, KeyContainer>& x,
+            flat_set<Key, Compare, KeyContainer>& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \constraints \tcode{is_nothrow_swappable_v<Container> \&\&
+\pnum \constraints \tcode{is_nothrow_swappable_v<KeyContainer> \&\&
 is_nothrow_swappable_v<Compare>} is \tcode{true}.
 
 \pnum
@@ -12528,7 +12528,7 @@ in \iref{container.requirements.general}.
 \rSec3[flatmultiset.defn]{Definition}
 
 \begin{codeblock}
-template <class Key, class Compare = less<Key>, class Container = vector<Key>>
+template <class Key, class Compare = less<Key>, class KeyContainer = vector<Key>>
 class flat_multiset {
   public:
     // types
@@ -12544,7 +12544,7 @@ class flat_multiset {
     using const_iterator            = @\impdefx{type of \tcode{flat_multiset::const_iterator}}@; // see \ref{container.requirements}
     using reverse_iterator          = std::reverse_iterator<iterator>;
     using const_reverse_iterator    = std::reverse_iterator<const_iterator>;
-    using container_type            = Container;
+    using container_type            = KeyContainer;
 
     // \ref{flatmultiset.cons}, construct/copy/destroy
     flat_multiset() : flat_multiset(key_compare()) { }
@@ -13038,9 +13038,9 @@ c = std::move(cont);
 
 \indexlibrary{\idxcode{operator==}!\idxcode{flatmultiset}}%
 \begin{itemdecl}
-template<class Key, class Compare, class Container>
-  bool operator==(const flat_multiset<Key, Compare, Container>& x,
-                  const flat_multiset<Key, Compare, Container>& y);
+template<class Key, class Compare, class KeyContainer>
+  bool operator==(const flat_multiset<Key, Compare, KeyContainer>& x,
+                  const flat_multiset<Key, Compare, KeyContainer>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -13051,9 +13051,9 @@ template<class Key, class Compare, class Container>
 
 \indexlibrary{\idxcode{operator!=}!\idxcode{flatmultiset}}%
 \begin{itemdecl}
-template<class Key, class Compare, class Container>
-  bool operator!=(const flat_multiset<Key, Compare, Container>& x,
-                  const flat_multiset<Key, Compare, Container>& y);
+template<class Key, class Compare, class KeyContainer>
+  bool operator!=(const flat_multiset<Key, Compare, KeyContainer>& x,
+                  const flat_multiset<Key, Compare, KeyContainer>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -13062,9 +13062,9 @@ template<class Key, class Compare, class Container>
 
 \indexlibrary{\idxcode{operator<}!\idxcode{flatmultiset}}%
 \begin{itemdecl}
-template<class Key, class Compare, class Container>
-  bool operator< (const flat_multiset<Key, Compare, Container>& x,
-                  const flat_multiset<Key, Compare, Container>& y);
+template<class Key, class Compare, class KeyContainer>
+  bool operator< (const flat_multiset<Key, Compare, KeyContainer>& x,
+                  const flat_multiset<Key, Compare, KeyContainer>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -13075,9 +13075,9 @@ template<class Key, class Compare, class Container>
 
 \indexlibrary{\idxcode{operator>}!\idxcode{flatmultiset}}%
 \begin{itemdecl}
-template<class Key, class Compare, class Container>
-  bool operator> (const flat_multiset<Key, Compare, Container>& x,
-                  const flat_multiset<Key, Compare, Container>& y);
+template<class Key, class Compare, class KeyContainer>
+  bool operator> (const flat_multiset<Key, Compare, KeyContainer>& x,
+                  const flat_multiset<Key, Compare, KeyContainer>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -13086,9 +13086,9 @@ template<class Key, class Compare, class Container>
 
 \indexlibrary{\idxcode{operator<=}!\idxcode{flatmultiset}}%
 \begin{itemdecl}
-template<class Key, class Compare, class Container>
-  bool operator<=(const flat_multiset<Key, Compare, Container>& x,
-                  const flat_multiset<Key, Compare, Container>& y);
+template<class Key, class Compare, class KeyContainer>
+  bool operator<=(const flat_multiset<Key, Compare, KeyContainer>& x,
+                  const flat_multiset<Key, Compare, KeyContainer>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -13097,9 +13097,9 @@ template<class Key, class Compare, class Container>
 
 \indexlibrary{\idxcode{operator>=}!\idxcode{flatmultiset}}%
 \begin{itemdecl}
-template<class Key, class Compare, class Container>
-  bool operator>=(const flat_multiset<Key, Compare, Container>& x,
-                  const flat_multiset<Key, Compare, Container>& y);
+template<class Key, class Compare, class KeyContainer>
+  bool operator>=(const flat_multiset<Key, Compare, KeyContainer>& x,
+                  const flat_multiset<Key, Compare, KeyContainer>& y);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -13110,13 +13110,13 @@ template<class Key, class Compare, class Container>
 
 \indexlibrarymember{swap}{flatmultiset}%
 \begin{itemdecl}
-template<class Key, class Compare, class Container>
-  void swap(flat_multiset<Key, Compare, Container>& x,
-            flat_multiset<Key, Compare, Container>& y) noexcept;
+template<class Key, class Compare, class KeyContainer>
+  void swap(flat_multiset<Key, Compare, KeyContainer>& x,
+            flat_multiset<Key, Compare, KeyContainer>& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \constraints \tcode{is_nothrow_swappable_v<Container> \&\&
+\pnum \constraints \tcode{is_nothrow_swappable_v<KeyContainer> \&\&
 is_nothrow_swappable_v<Compare>} is \tcode{true}.
 
 \pnum

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -11907,9 +11907,15 @@ namespace std {
     template <class Container>
       explicit flat_set(const Container& cont)
         : flat_set(cont.begin(), cont.end(), key_compare()) { }
+    template<class Container>
+    flat_set(const Container& cont, const key_compare& comp)
+        : flat_set(std::begin(cont), std::end(cont), comp) { }
     template <class Container, class Alloc>
       flat_set(const Container& cont, const Alloc& a)
         : flat_set(cont.begin(), cont.end(), key_compare(), a) { }
+    template <class Container, class Alloc>
+      flat_set(const Container& cont, const key_compare& comp, const Alloc& a)
+        : flat_set(std::begin(cont), std::end(cont), comp, a) { }
 
     flat_set(sorted_unique_t, container_type cont)
       : c(std::move(cont)), compare(key_compare()) { }
@@ -11919,9 +11925,15 @@ namespace std {
     template <class Container>
       flat_set(sorted_unique_t s, const Container& cont)
         : flat_set(s, cont.begin(), cont.end(), key_compare()) { }
+    template<class Container>
+    flat_set(sorted_unique_t s, const Container& cont, const key_compare& comp)
+        : flat_set(s, std::begin(cont), std::end(cont), comp) { }
     template <class Container, class Alloc>
       flat_set(sorted_unique_t s, const Container& cont, const Alloc& a)
         : flat_set(s, cont.begin(), cont.end(), key_compare(), a) { }
+    template<class Container, class Alloc>
+    flat_set(sorted_unique_t s, const Container& cont, const key_compare& comp, const Alloc& a)
+        : flat_set(s, std::begin(cont), std::end(cont), comp, a) { }
 
     explicit flat_set(const key_compare& comp)
       : c(container_type()), compare(comp) { }
@@ -12561,9 +12573,15 @@ class flat_multiset {
     template <class Container>
       explicit flat_multiset(const Container& cont)
         : flat_multiset(cont.begin(), cont.end(), key_compare()) { }
+    template<class Container>
+    flat_multiset(const Container& cont, const key_compare& comp)
+        : flat_multiset(std::begin(cont), std::end(cont), comp) { }
     template <class Container, class Alloc>
       flat_multiset(const Container& cont, const Alloc& a)
         : flat_multiset(cont.begin(), cont.end(), key_compare(), a) { }
+    template<class Container>
+    flat_multiset(const Container& cont, const key_compare& comp, const Alloc& a)
+        : flat_multiset(std::begin(cont), std::end(cont), comp, a) { }
 
     flat_multiset(sorted_equivalent_t, container_type cont)
       : c(std::move(cont)), compare(key_compare()) { }
@@ -12573,9 +12591,16 @@ class flat_multiset {
     template <class Container>
       flat_multiset(sorted_equivalent_t s, const Container& cont)
         : flat_multiset(s, cont.begin(), cont.end(), key_compare()) { }
+
+    template<class Container>
+    flat_multiset(sorted_equivalent_t s, const Container& cont, const key_compare& comp)
+        : flat_multiset(s, std::begin(cont), std::end(cont), comp) { }
     template <class Container, class Alloc>
       flat_multiset(sorted_equivalent_t s, const Container& cont, const Alloc& a)
         : flat_multiset(s, cont.begin(), cont.end(), key_compare(), a) { }
+    template<class Container>
+    flat_multiset(sorted_equivalent_t s, const Container& cont, const key_compare& comp, const Alloc& a)
+        : flat_multiset(s, std::begin(cont), std::end(cont), comp, a) { }
 
     explicit flat_multiset(const key_compare& comp)
       : c(container_type()), compare(comp) { }

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9913,10 +9913,6 @@ key value) and provides for fast retrieval of values of another type \tcode{T}
 based on the keys. The \tcode{flat_map} class supports random access
 iterators.
 
-%TODO: Front matter should say that it's an invariant that keys and values are
-%the same size.  See first part of array overview. time.zone.overview too?
-%Also, that the elements are sroted w.r.t. compare.
-
 \pnum
 A \tcode{flat_map} satisfies all of the requirements of a container, of a
 reversible container\iref{container.requirements}, and of an associative
@@ -9935,9 +9931,17 @@ a \tcode{flat_map<Key,T>} the \tcode{key_type} is \tcode{Key} and the
 \tcode{value_type} is \tcode{pair<const Key,T>}.
 
 \pnum
-Descriptions are provided here only for operations on \tcode{flat_map}
-that are not described in one of those tables or for operations where
-there is additional semantic information.
+A \tcode{flat_map} \tcode{m} maintains these invariants: it contains the same
+number of keys and values; the keys are sorted with respect to the its
+comparison object; and the value at offset \tcode{o} within the value
+container is the value associated with the key at offset \tcode{o} within the
+key container.  That is, this key-value pair is used to form the
+value \tcode{*(m.begin() + o)}.
+
+\pnum
+Descriptions are provided here only for operations on \tcode{flat_map} that
+are not described in one of those tables or for operations where there is
+additional semantic information.
 
 \pnum
 Any sequence container supporting random access iteration can be used to
@@ -11014,6 +11018,14 @@ in~\ref{associative.reqmts} for equal keys.  This means that a
 in~\ref{associative.reqmts} but not the \tcode{a_uniq} operations.  For
 a \tcode{flat_multimap<Key,T>} the \tcode{key_type} is \tcode{Key} and the
 \tcode{value_type} is \tcode{pair<const Key,T>}.
+
+\pnum
+A \tcode{flat_multimap} \tcode{m} maintains these invariants: it contains the
+same number of keys and values; the keys are sorted with respect to the its
+comparison object; and the value at offset \tcode{o} within the value
+container is the value associated with the key at offset \tcode{o} within the
+key container.  That is, this key-value pair is used to form the
+value \tcode{*(m.begin() + o)}.
 
 \pnum
 Descriptions are provided here only for operations on \tcode{flat_multimap}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10142,7 +10142,8 @@ namespace std {
       void swap(flat_map& fm)
         noexcept(
           noexcept(declval<key_container_type>().swap(declval<key_container_type&>())) &&
-          noexcept(declval<mapped_container_type>().swap(declval<mapped_container_type&>()))
+          noexcept(declval<mapped_container_type>().swap(declval<mapped_container_type&>()) &&
+          noexcept(declval<key_compare>().swap(declval<key_compare&>()))
         );
       void clear() noexcept;
 
@@ -11135,7 +11136,8 @@ namespace std {
       void swap(flat_multimap& fm)
         noexcept(
           noexcept(declval<key_container_type>().swap(declval<key_container_type&>())) &&
-          noexcept(declval<mapped_container_type>().swap(declval<mapped_container_type&>()))
+          noexcept(declval<mapped_container_type>().swap(declval<mapped_container_type&>()) &&
+          noexcept(declval<key_compare>().swap(declval<key_compare&>()))
         );
       void clear() noexcept;
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10382,7 +10382,7 @@ flat_map(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
 \pnum
 \complexity
 Linear in $N$ if the container arguments are already sorted as if
-with \tcode{comp} and otherwise $N \log N$, where $N$
+with \tcode{compare} and otherwise $N \log N$, where $N$
 is \tcode{key_cont.size()}.
 \end{itemdescr}
 
@@ -11394,7 +11394,7 @@ flat_multimap(key_container_type&& key_cont, mapped_container_type&& mapped_cont
 \pnum
 \complexity
 Linear in $N$ if the container arguments are already sorted as if
-with \tcode{comp} and otherwise $N \log N$, where $N$
+with \tcode{compare} and otherwise $N \log N$, where $N$
 is \tcode{key_cont.size()}.
 \end{itemdescr}
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9966,7 +9966,7 @@ argument with a range that is not sorted with respect to \tcode{compare} is
 undefined.
 
 \pnum
-Constructors that take a \tcode{Alloc} argument shall participate in overload
+Constructors that take an \tcode{Alloc} argument shall participate in overload
 resolution only if \tcode{uses_allocator_v<key_container_type, Alloc> ||
   uses_allocator_v<mapped_container_type, Alloc>} is \tcode{true}.
 
@@ -10984,7 +10984,6 @@ is \tcode{true}.
 
 \pnum
 \indexlibrary{\idxcode{flatmultimap}}%
-\pnum
 A \tcode{flat_multimap} is a container adaptor that provides an associative
 container interface that supports equivalent keys (possibly containing
 multiple copies of the same key value) and provides for fast retrieval of
@@ -10996,10 +10995,9 @@ A \tcode{flat_multimap} satisfies all of the requirements of a container, of a
 reversible container\iref{container.requirements}, and of an associative
 container\iref{associative.reqmts}, except for the requirements related to
 node handles\iref{container.node} and iterator
-invalidation\iref{container.adaptors.general}.  A \tcode{flat_multimap}
-does not meet the additional requirements of an allocator-aware container, as
-described in
-\tref{containers.allocatoraware}.
+invalidation\iref{container.adaptors.general}.  A \tcode{flat_multimap} does
+not meet the additional requirements of an allocator-aware container, as
+described in \tref{containers.allocatoraware}.
 
 \pnum
 A \tcode{flat_multimap} also provides most operations described
@@ -11037,10 +11035,9 @@ and \tcode{mapped_container_type} arguments with containers of different sizes i
 undefined.
 
 \pnum
-Constructors in this subclause that take a \tcode{Container}
-argument \tcode{cont} shall participate in overload resolution only if
-both \tcode{std::begin(cont)} and \tcode{std::end(cont)} are well-formed
-expressions.
+Constructors that take a \tcode{Container} argument \tcode{cont} shall
+participate in overload resolution only if both \tcode{std::begin(cont)}
+and \tcode{std::end(cont)} are well-formed expressions.
 
 \pnum
 The effect of calling a constructor that takes a \tcode{sorted_equivalent_t}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10161,9 +10161,9 @@ namespace std {
 
       void swap(flat_map& fm)
         noexcept(
-          noexcept(declval<key_container_type>().swap(declval<key_container_type&>())) &&
-          noexcept(declval<mapped_container_type>().swap(declval<mapped_container_type&>()) &&
-          noexcept(declval<key_compare>().swap(declval<key_compare&>()))
+          is_nothrow_swappable_v<key_container_type> &&
+          is_nothrow_swappable_v<mapped_container_type> &&
+          is_nothrow_swappable_v<key_compare>
         );
       void clear() noexcept;
 
@@ -11192,9 +11192,9 @@ namespace std {
 
       void swap(flat_multimap& fm)
         noexcept(
-          noexcept(declval<key_container_type>().swap(declval<key_container_type&>())) &&
-          noexcept(declval<mapped_container_type>().swap(declval<mapped_container_type&>()) &&
-          noexcept(declval<key_compare>().swap(declval<key_compare&>()))
+          is_nothrow_swappable_v<key_container_type> &&
+          is_nothrow_swappable_v<mapped_container_type> &&
+          is_nothrow_swappable_v<key_compare>
         );
       void clear() noexcept;
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9907,10 +9907,11 @@ unless \tcode{is_swappable_v<Container>} is \tcode{true}.
 
 \pnum
 \indexlibrary{\idxcode{flatmap}}%
-A \tcode{flat_map} is an associative container adaptor that
-supports unique keys (contains at most one of each key value) and
-provides for fast retrieval of values of another type \tcode{T} based
-on the keys. The \tcode{flat_map} class supports random access iterators.
+A \tcode{flat_map} is a container adaptor that provides an associative
+container interface that supports unique keys (contains at most one of each
+key value) and provides for fast retrieval of values of another type \tcode{T}
+based on the keys. The \tcode{flat_map} class supports random access
+iterators.
 
 \pnum
 A \tcode{flat_map} satisfies all of the requirements of a container, of a
@@ -10948,10 +10949,11 @@ is \tcode{true}.
 \pnum
 \indexlibrary{\idxcode{flatmultimap}}%
 \pnum
-A \tcode{flat_multimap} is an associative container adaptor that supports
-equivalent keys (possibly containing multiple copies of the same key value)
-and provides for fast retrieval of values of another type \tcode{T} based on
-the keys. The \tcode{flat_multimap} class supports random access iterators.
+A \tcode{flat_multimap} is a container adaptor that provides an associative
+container interface that supports equivalent keys (possibly containing
+multiple copies of the same key value) and provides for fast retrieval of
+values of another type \tcode{T} based on the keys. The \tcode{flat_multimap}
+class supports random access iterators.
 
 \pnum
 A \tcode{flat_multimap} satisfies all of the requirements of a container, of a

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -12082,83 +12082,67 @@ namespace std {
 
   template <class Container>
     flat_set(Container)
-      -> flat_set<@\placeholder{cont-value-type}@<Container>,
-                  less<@\placeholder{cont-value-type}@<Container>>,
-                  vector<@\placeholder{cont-value-type}@<Container>>>;
+      -> flat_set<@\placeholder{cont-value-type}@<Container>>;
 
   template <class Container, class Alloc>
     flat_set(Container, Alloc)
-      -> flat_set<@\placeholder{cont-value-type}@<Container>,
-                  less<@\placeholder{cont-value-type}@<Container>>,
-                  vector<@\placeholder{cont-value-type}@<Container>>>;
+      -> flat_set<@\placeholder{cont-value-type}@<Container>>;
 
   template <class Container>
     flat_set(sorted_unique_t, Container)
-      -> flat_set<@\placeholder{cont-value-type}@<Container>,
-                  less<@\placeholder{cont-value-type}@<Container>>,
-                  vector<@\placeholder{cont-value-type}@<Container>>>;
+      -> flat_set<@\placeholder{cont-value-type}@<Container>>;
 
   template <class Container, class Alloc>
     flat_set(sorted_unique_t, Container, Alloc)
-      -> flat_set<@\placeholder{cont-value-type}@<Container>,
-                  less<@\placeholder{cont-value-type}@<Container>>,
-                  vector<@\placeholder{cont-value-type}@<Container>>>;
+      -> flat_set<@\placeholder{cont-value-type}@<Container>>;
 
   template <class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
     flat_set(InputIterator, InputIterator, Compare = Compare())
-      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare,
-                  vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
   template<class InputIterator, class Compare, class Alloc>
     flat_set(InputIterator, InputIterator, Compare, Alloc)
-      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare,
-                  vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
   template<class InputIterator, class Alloc>
     flat_set(InputIterator, InputIterator, Alloc)
-      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>,
-                  less<@\placeholder{iter-value-type}@<InputIterator>>,
-                  vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>>;
 
   template <class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
     flat_set(sorted_unique_t, InputIterator, InputIterator, Compare = Compare())
-      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare,
-                  vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
   template<class InputIterator, class Compare, class Alloc>
     flat_set(sorted_unique_t, InputIterator, InputIterator, Compare, Alloc)
-      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare,
-                  vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
   template<class InputIterator, class Alloc>
     flat_set(sorted_unique_t, InputIterator, InputIterator, Alloc)
-      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>,
-                  less<@\placeholder{iter-value-type}@<InputIterator>>,
-                  vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>>;
 
   template<class Key, class Compare = less<Key>>
     flat_set(initializer_list<Key>, Compare = Compare())
-      -> flat_set<Key, Compare, vector<Key>>;
+      -> flat_set<Key, Compare>;
 
   template<class Key, class Compare, class Alloc>
     flat_set(initializer_list<Key>, Compare, Alloc)
-      -> flat_set<Key, Compare, vector<Key>>;
+      -> flat_set<Key, Compare>;
 
   template<class Key, class Alloc>
     flat_set(initializer_list<Key>, Alloc)
-      -> flat_set<Key, less<Key>, vector<Key>>;
+      -> flat_set<Key>;
 
   template<class Key, class Compare = less<Key>>
     flat_set(sorted_unique_t, initializer_list<Key>, Compare = Compare())
-      -> flat_set<Key, Compare, vector<Key>>;
+      -> flat_set<Key, Compare>;
 
   template<class Key, class Compare, class Alloc>
     flat_set(sorted_unique_t, initializer_list<Key>, Compare, Alloc)
-      -> flat_set<Key, Compare, vector<Key>>;
+      -> flat_set<Key, Compare>;
 
   template<class Key, class Alloc>
     flat_set(sorted_unique_t, initializer_list<Key>, Alloc)
-      -> flat_set<Key, less<Key>, vector<Key>>;
+      -> flat_set<Key>;
 }
 \end{codeblock}
 
@@ -12753,85 +12737,67 @@ class flat_multiset {
 
   template <class Container>
     flat_multiset(Container)
-      -> flat_multiset<@\placeholder{cont-value-type}@<Container>,
-                       less<@\placeholder{cont-value-type}@<Container>>,
-                       vector<@\placeholder{cont-value-type}@<Container>>>;
+      -> flat_multiset<@\placeholder{cont-value-type}@<Container>>;
 
   template <class Container, class Alloc>
     flat_multiset(Container, Alloc)
-      -> flat_multiset<@\placeholder{cont-value-type}@<Container>,
-                       less<@\placeholder{cont-value-type}@<Container>>,
-                       vector<@\placeholder{cont-value-type}@<Container>>>;
+      -> flat_multiset<@\placeholder{cont-value-type}@<Container>>;
 
   template <class Container>
     flat_multiset(sorted_equivalent_t, Container)
-      -> flat_multiset<@\placeholder{cont-value-type}@<Container>,
-                       less<@\placeholder{cont-value-type}@<Container>>,
-                       vector<@\placeholder{cont-value-type}@<Container>>>;
+      -> flat_multiset<@\placeholder{cont-value-type}@<Container>>;
 
   template <class Container, class Alloc>
     flat_multiset(sorted_equivalent_t, Container, Alloc)
-      -> flat_multiset<@\placeholder{cont-value-type}@<Container>,
-                       less<@\placeholder{cont-value-type}@<Container>>,
-                       vector<@\placeholder{cont-value-type}@<Container>>>;
+      -> flat_multiset<@\placeholder{cont-value-type}@<Container>>;
 
   template <class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
     flat_multiset(InputIterator, InputIterator, Compare = Compare())
-      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>,
-                       less<@\placeholder{iter-value-type}@<InputIterator>>,
-                       vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
   template<class InputIterator, class Compare, class Alloc>
     flat_multiset(InputIterator, InputIterator, Compare, Alloc)
-      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare,
-                       vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
   template<class InputIterator, class Alloc>
     flat_multiset(InputIterator, InputIterator, Alloc)
-      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>,
-                       less<@\placeholder{iter-value-type}@<InputIterator>>,
-                       vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>>;
 
   template <class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
     flat_multiset(sorted_equivalent_t, InputIterator, InputIterator, Compare = Compare())
-      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>,
-                       less<@\placeholder{iter-value-type}@<InputIterator>>,
-                       vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
   template<class InputIterator, class Compare, class Alloc>
     flat_multiset(sorted_equivalent_t, InputIterator, InputIterator, Compare, Alloc)
-      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare,
-                       vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
   template<class InputIterator, class Alloc>
     flat_multiset(sorted_equivalent_t, InputIterator, InputIterator, Alloc)
-      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>,
-                       less<@\placeholder{iter-value-type}@<InputIterator>>,
-                       vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>>;
 
   template<class Key, class Compare = less<Key>>
     flat_multiset(initializer_list<Key>, Compare = Compare())
-      -> flat_multiset<Key, Compare, vector<Key>>;
+      -> flat_multiset<Key, Compare>;
 
   template<class Key, class Compare, class Alloc>
     flat_multiset(initializer_list<Key>, Compare, Alloc)
-      -> flat_multiset<Key, Compare, vector<Key>>;
+      -> flat_multiset<Key, Compare>;
 
   template<class Key, class Alloc>
     flat_multiset(initializer_list<Key>, Alloc)
-      -> flat_multiset<Key, less<Key>, vector<Key>>;
+      -> flat_multiset<Key>;
 
   template<class Key, class Compare = less<Key>>
   flat_multiset(sorted_equivalent_t, initializer_list<Key>, Compare = Compare())
-      -> flat_multiset<Key, Compare, vector<Key>>;
+      -> flat_multiset<Key, Compare>;
 
   template<class Key, class Compare, class Alloc>
     flat_multiset(sorted_equivalent_t, initializer_list<Key>, Compare, Alloc)
-      -> flat_multiset<Key, Compare, vector<Key>>;
+      -> flat_multiset<Key, Compare>;
 
   template<class Key, class Alloc>
   flat_multiset(sorted_equivalent_t, initializer_list<Key>, Alloc)
-      -> flat_multiset<Key, less<Key>, vector<Key>>;
+      -> flat_multiset<Key>;
 }
 \end{codeblock}
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -30,7 +30,7 @@ as summarized in
 \ref{container.adaptors}     & Container adaptors               & \tcode{<queue>}         \\
                              &                                  & \tcode{<stack>}         \\
                              &                                  & \added{\tcode{<flat_map>}}      \\
-                             &                                  & \added{\tcode{<flat_multimap>}} \\ \rowsep
+                             &                                  & \added{\tcode{<flat_set>}} \\ \rowsep
 \ref{views}                  & Views                            & \tcode{<span>}          \\ \rowsep
 \end{libsumtab}
 
@@ -754,8 +754,9 @@ linear arrangement. The library provides four basic kinds of sequence containers
 because it has a fixed number of elements. The library also provides container
 adaptors that make it easy to construct abstract data types, such
 as \tcode{stack}s, \tcode{queue}s, \added{\tcode{flat_map}s,
-or \tcode{flat_multimap}s, }out of the basic sequence container kinds (or out
-of other kinds of sequence containers).
+\tcode{flat_multimap}s, \tcode{flat_set}s, or \tcode{flat_multiset}s,
+}out of the basic sequence container kinds (or out of other kinds of sequence
+containers).
 
 \pnum
 \begin{note}
@@ -1497,10 +1498,11 @@ The library provides four basic kinds of associative containers:
 \tcode{multiset},
 \tcode{map}
 and
-\tcode{multimap}.\added{  The library also provides container adaptors that
-make it easy to construct abstract data types, such as \tcode{flat_map}s
-or \tcode{flat_multimap}s, out of the basic sequence container kinds (or out
-of other program-defined sequence containers).}
+\tcode{multimap}.\added{ The library also provides container adaptors that
+make it easy to construct abstract data types, such as \tcode{flat_map}s,
+\tcode{flat_multimap}s, \tcode{flat_set}s, or \tcode{flat_multiset}s, out of
+the basic sequence container kinds (or out of other program-defined sequence
+containers).}
 
 \pnum
 Each associative container is parameterized on
@@ -8908,10 +8910,10 @@ for the first form, or from the range
 \rSec2[container.adaptors.general]{In general}
 
 \pnum
-The headers \tcode{<queue>}\changed{ and}{,} \tcode{<stack>}\added{, and
-\tcode{<flat_map>}} define the container adaptors \tcode{queue},
-\tcode{priority_queue}\changed{ and}{,} \tcode{stack}\added{, and
-\tcode{flat_map}}.
+The headers \tcode{<queue>}\changed{ and}{,} \tcode{<stack>}\added{,
+\tcode{<flat_map>} and \tcode{<flat_set>}} define the container adaptors
+\tcode{queue}, \tcode{priority_queue}\changed{ and}{,} \tcode{stack}\added{,
+\tcode{flat_map}, and \tcode{flat_set}}.
 
 \pnum
 For container adaptors, no \tcode{swap} function throws an exception unless
@@ -9086,6 +9088,69 @@ namespace std {
 
   struct sorted_equivalent_t { explicit sorted_equivalent_t() = default; };
   inline constexpr sorted_equivalent_t sorted_equivalent {};
+}
+\end{codeblock}
+
+\rSec2[flatset.syn]{Header \tcode{<flat_set>} synopsis}%
+\indexhdr{flatset}%
+
+\begin{codeblock}
+#include <initializer_list>
+
+namespace std {
+  // \ref{flatset}, class template \tcode{flat_set}
+  template<class Key, class Compare = less<Key>, class Container = vector<Key>>
+    class flat_set;
+
+  template<class Key, class Compare, class Container>
+    bool operator==(const flat_set<Key, Compare, Container>& x,
+                    const flat_set<Key, Compare, Container>& y);
+  template<class Key, class Compare, class Container>
+    bool operator!=(const flat_set<Key, Compare, Container>& x,
+                    const flat_set<Key, Compare, Container>& y);
+  template<class Key, class Compare, class Container>
+    bool operator< (const flat_set<Key, Compare, Container>& x,
+                    const flat_set<Key, Compare, Container>& y);
+  template<class Key, class Compare, class Container>
+    bool operator> (const flat_set<Key, Compare, Container>& x,
+                    const flat_set<Key, Compare, Container>& y);
+  template<class Key, class Compare, class Container>
+    bool operator<=(const flat_set<Key, Compare, Container>& x,
+                    const flat_set<Key, Compare, Container>& y);
+  template<class Key, class Compare, class Container>
+    bool operator>=(const flat_set<Key, Compare, Container>& x,
+                    const flat_set<Key, Compare, Container>& y);
+
+  template<class Key, class Compare, class Container>
+    void swap(flat_set<Key, Compare, Container>& x,
+              flat_set<Key, Compare, Container>& y) noexcept;
+
+  // \ref{flatmultiset}, class template \tcode{flat_multiset}
+  template<class Key, class Compare = less<Key>, class Container = vector<Key>>
+    class flat_multiset;
+
+  template<class Key, class Compare, class Container>
+    bool operator==(const flat_multiset<Key, Compare, Container>& x,
+                    const flat_multiset<Key, Compare, Container>& y);
+  template<class Key, class Compare, class Container>
+    bool operator!=(const flat_multiset<Key, Compare, Container>& x,
+                    const flat_multiset<Key, Compare, Container>& y);
+  template<class Key, class Compare, class Container>
+    bool operator< (const flat_multiset<Key, Compare, Container>& x,
+                    const flat_multiset<Key, Compare, Container>& y);
+  template<class Key, class Compare, class Container>
+    bool operator> (const flat_multiset<Key, Compare, Container>& x,
+                    const flat_multiset<Key, Compare, Container>& y);
+  template<class Key, class Compare, class Container>
+    bool operator<=(const flat_multiset<Key, Compare, Container>& x,
+                    const flat_multiset<Key, Compare, Container>& y);
+  template<class Key, class Compare, class Container>
+    bool operator>=(const flat_multiset<Key, Compare, Container>& x,
+                    const flat_multiset<Key, Compare, Container>& y);
+
+  template<class Key, class Compare, class Container>
+    void swap(flat_multiset<Key, Compare, Container>& x,
+              flat_multiset<Key, Compare, Container>& y) noexcept;
 }
 \end{codeblock}
 \end{addedblock}
@@ -11749,6 +11814,571 @@ is \tcode{true}.
 \pnum
 \effects Equivalent to: \tcode{x.swap(y)}.
 \end{itemdescr}
+
+\rSec2[flatset]{Class template \tcode{flat_set}}
+
+\pnum
+\indexlibrary{\idxcode{flatset}}%
+A \tcode{flat_set} is a container adaptor that provides an associative
+container interface that supports unique keys (contains at most one of each
+key value) and provides for fast retrieval of the keys themselves. The
+\tcode{flat_set} class supports random access iterators.
+
+\pnum
+A \tcode{flat_set} satisfies all of the requirements of a container, of a
+reversible container\iref{container.requirements}, and of an associative
+container\iref{associative.reqmts}, except for the requirements related to
+node handles\iref{container.node} and iterator
+invalidation\iref{container.adaptors.general}.  A \tcode{flat_set} does not
+meet the additional requirements of an allocator-aware container, as described
+in \tref{containers.allocatoraware}.
+
+\pnum
+A \tcode{flat_set} also provides most operations described
+in~\ref{associative.reqmts} for unique keys.  This means that a
+\tcode{flat_set} supports the \tcode{a_uniq} operations
+in~\ref{associative.reqmts} but not the \tcode{a_eq} operations.  For a
+\tcode{flat_set<Key,T>} both the \tcode{key_type} and \tcode{key_type} are
+\tcode{Key}.
+
+\pnum
+Descriptions are provided here only for operations on \tcode{flat_set} that
+are not described in one of those tables or for operations where there is
+additional semantic information.
+
+\pnum
+Any sequence container supporting random access iteration can be used to
+instantiate \tcode{flat_set}. In particular, \tcode{vector}\iref{vector} and
+\tcode{deque}\iref{deque} can be used.
+
+\pnum
+The template parameter \tcode{Key} shall denote the same type as
+\tcode{Container::value_type}.
+
+\pnum
+Constructors that take a \tcode{Container} argument \tcode{cont} shall
+participate in overload resolution only if both \tcode{std::begin(cont)} and
+\tcode{std::end(cont)} are well-formed expressions.
+
+\pnum
+The effect of calling a constructor that takes a \tcode{sorted_unique_t}
+argument with a range that is not sorted with respect to \tcode{compare} is
+undefined.
+
+\pnum
+Constructors that take a \tcode{Alloc} argument shall participate in overload
+resolution only if \tcode{uses_allocator_v<container_type, Alloc>} is
+\tcode{true}.
+
+\pnum
+Constructors that take an \tcode{Alloc} argument shall participate in overload
+resolution only if \tcode{Alloc} meets the allocator requirements as described
+in \iref{container.requirements.general}.
+
+\rSec3[flatset.defn]{Definition}
+
+\begin{codeblock}
+namespace std {
+  template <class Key, class Compare = less<Key>, class Container = vector<Key>>
+  class flat_set {
+  public:
+      // types:
+      using key_type                  = Key;
+      using key_compare               = Compare;
+      using value_type                = Key;
+      using value_compare             = Compare;
+      using reference                 = value_type&;
+      using const_reference           = const value_type&;
+      using size_type                 = size_t;
+      using difference_type           = ptrdiff_t;
+      using iterator                  = @\impdefx{type of \tcode{flat_set::iterator}}@; // see \ref{container.requirements}
+      using const_iterator            = @\impdefx{type of \tcode{flat_set::const_iterator}}@; // see \ref{container.requirements}
+      using reverse_iterator          = std::reverse_iterator<iterator>;
+      using const_reverse_iterator    = std::reverse_iterator<const_iterator>;
+      using container_type            = Container;
+
+      // \ref{flatset.cons}, construct/copy/destroy
+      flat_set();
+
+      explicit flat_set(container_type);
+      template <class Alloc>
+        flat_set(container_type, const Alloc&);
+      flat_set(sorted_unique_t, container_type);
+      template <class Alloc>
+        flat_set(sorted_unique_t, container_type, const Alloc&);
+      explicit flat_set(const key_compare& comp);
+      template <class Alloc>
+        flat_set(const key_compare& comp, const Alloc&);
+      template <class Alloc>
+        explicit flat_set(const Alloc&);
+
+      template <class InputIterator>
+        flat_set(InputIterator first, InputIterator last,
+                 const key_compare& comp = key_compare());
+      template <class InputIterator, class Alloc>
+        flat_set(InputIterator first, InputIterator last,
+                 const key_compare& comp, const Alloc&);
+      template <class InputIterator, class Alloc>
+        flat_set(InputIterator first, InputIterator last, const Alloc& a)
+          : flat_set(first, last, key_compare(), a) { }
+
+      template <class InputIterator>
+        flat_set(sorted_unique_t, InputIterator first, InputIterator last,
+                 const key_compare& comp = key_compare());
+      template <class InputIterator, class Alloc>
+        flat_set(sorted_unique_t, InputIterator first, InputIterator last,
+                 const key_compare& comp, const Alloc&);
+      template <class InputIterator, class Alloc>
+        flat_set(sorted_unique_t t, InputIterator first, InputIterator last,
+                 const Alloc& a)
+          : flat_set(t, first, last, key_compare(), a) { }
+      template <class Alloc>
+        flat_set(flat_set, const Alloc&);
+
+      flat_set(initializer_list<key_type>, const key_compare& = key_compare());
+      template <class Alloc>
+        flat_set(initializer_list<key_type>, const key_compare&, const Alloc&);
+      template <class Alloc>
+        flat_set(initializer_list<key_type> il, const Alloc& a)
+          : flat_set(il, key_compare(), a) { }
+
+      flat_set(sorted_unique_t, initializer_list<key_type>,
+               const key_compare& = key_compare());
+      template <class Alloc>
+        flat_set(sorted_unique_t, initializer_list<key_type>,
+                 const key_compare&, const Alloc&);
+      template <class Alloc>
+        flat_set(sorted_unique_t t, initializer_list<key_type> il,
+                 const Alloc& a)
+          : flat_set(t, il, key_compare(), a) { }
+
+      flat_set& operator=(initializer_list<key_type>);
+  
+      // iterators
+      iterator               begin() noexcept;
+      const_iterator         begin() const noexcept;
+      iterator               end() noexcept;
+      const_iterator         end() const noexcept;
+
+      reverse_iterator       rbegin() noexcept;
+      const_reverse_iterator rbegin() const noexcept;
+      reverse_iterator       rend() noexcept;
+      const_reverse_iterator rend() const noexcept;
+
+      const_iterator         cbegin() const noexcept;
+      const_iterator         cend() const noexcept;
+      const_reverse_iterator crbegin() const noexcept;
+      const_reverse_iterator crend() const noexcept;
+
+      // \ref{flatset.capacity}, capacity
+      [[nodiscard]] bool empty() const noexcept;
+      size_type size() const noexcept;
+      size_type max_size() const noexcept;
+
+      // \ref{flatset.modifiers}, modifiers
+      template <class... Args> pair<iterator, bool> emplace(Args&&... args);
+      template <class... Args>
+        iterator emplace_hint(const_iterator position, Args&&... args);
+      pair<iterator, bool> insert(const value_type& x);
+      pair<iterator, bool> insert(value_type&& x);
+      iterator insert(const_iterator position, const value_type& x);
+      iterator insert(const_iterator position, value_type&& x);
+      template <class InputIterator>
+        void insert(InputIterator first, InputIterator last);
+      template <class InputIterator>
+        void insert(sorted_unique_t, InputIterator first, InputIterator last);
+      void insert(initializer_list<key_type>);
+      void insert(sorted_unique_t, initializer_list<key_type>);
+
+      container_type extract() &&;
+      void replace(container_type&&);
+
+      iterator erase(iterator position);
+      iterator erase(const_iterator position);
+      size_type erase(const key_type& x);
+      iterator erase(const_iterator first, const_iterator last);
+
+      void swap(flat_set& fs) noexcept(
+        is_nothrow_swappable_v<container_type> && is_nothrow_swappable_v<key_compare>
+      );
+      void clear() noexcept;
+
+      // observers
+      key_compare key_comp() const;
+      value_compare value_comp() const;
+  
+      // set operations
+      iterator find(const key_type& x);
+      const_iterator find(const key_type& x) const;
+      template <class K> iterator find(const K& x);
+      template <class K> const_iterator find(const K& x) const;
+
+      size_type count(const key_type& x) const;
+      template <class K> size_type count(const K& x) const;
+
+      bool contains(const key_type& x) const;
+      template <class K> bool contains(const K& x) const;
+
+      iterator lower_bound(const key_type& x);
+      const_iterator lower_bound(const key_type& x) const;
+      template <class K> iterator lower_bound(const K& x);
+      template <class K> const_iterator lower_bound(const K& x) const;
+
+      iterator upper_bound(const key_type& x);
+      const_iterator upper_bound(const key_type& x) const;
+      template <class K> iterator upper_bound(const K& x);
+      template <class K> const_iterator upper_bound(const K& x) const;
+
+      pair<iterator, iterator> equal_range(const key_type& x);
+      pair<const_iterator, const_iterator> equal_range(const key_type& x) const;
+      template <class K>
+        pair<iterator, iterator> equal_range(const K& x);
+      template <class K>
+        pair<const_iterator, const_iterator> equal_range(const K& x) const;
+  };
+
+  template <class Container>
+    using @\placeholder{cont-value-type}@ = typename Container::value_type; // \expos
+  template<class InputIterator>
+    using @\placeholder{iter-value-type}@ = remove_const_t<
+      typename iterator_traits<InputIterator>::value_type::first_type>;     // \expos
+
+  template <class Container>
+    flat_set(Container)
+      -> flat_set<@\placeholder{cont-value-type}@<Container>,
+                  less<@\placeholder{cont-value-type}@<Container>>,
+                  vector<@\placeholder{cont-value-type}@<Container>>>;
+
+  template <class Container, class Alloc>
+    flat_set(Container, Alloc)
+      -> flat_set<@\placeholder{cont-value-type}@<Container>,
+                  less<@\placeholder{cont-value-type}@<Container>>,
+                  vector<@\placeholder{cont-value-type}@<Container>>>;
+
+  template <class Container>
+    flat_set(sorted_unique_t, Container)
+      -> flat_set<@\placeholder{cont-value-type}@<Container>,
+                  less<@\placeholder{cont-value-type}@<Container>>,
+                  vector<@\placeholder{cont-value-type}@<Container>>>;
+
+  template <class Container, class Alloc>
+    flat_set(sorted_unique_t, Container, Alloc)
+      -> flat_set<@\placeholder{cont-value-type}@<Container>,
+                  less<@\placeholder{cont-value-type}@<Container>>,
+                  vector<@\placeholder{cont-value-type}@<Container>>>;
+
+  template <class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
+    flat_set(InputIterator, InputIterator, Compare = Compare())
+      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare,
+                  vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+
+  template<class InputIterator, class Compare, class Alloc>
+    flat_set(InputIterator, InputIterator, Compare, Alloc)
+      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare,
+                  vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+
+  template<class InputIterator, class Alloc>
+    flat_set(InputIterator, InputIterator, Alloc)
+      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>,
+                  less<@\placeholder{iter-value-type}@<InputIterator>>,
+                  vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+
+  template <class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
+    flat_set(sorted_unique_t, InputIterator, InputIterator, Compare = Compare())
+      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare,
+                  vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+
+  template<class InputIterator, class Compare, class Alloc>
+    flat_set(sorted_unique_t, InputIterator, InputIterator, Compare, Alloc)
+      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare,
+                  vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+
+  template<class InputIterator, class Alloc>
+    flat_set(sorted_unique_t, InputIterator, InputIterator, Alloc)
+      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>,
+                  less<@\placeholder{iter-value-type}@<InputIterator>>,
+                  vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+
+  template<class Key, class Compare = less<Key>>
+    flat_set(initializer_list<Key>, Compare = Compare())
+      -> flat_set<Key, Compare, vector<Key>>;
+
+  template<class Key, class Compare, class Alloc>
+    flat_set(initializer_list<Key>, Compare, Alloc)
+      -> flat_set<Key, Compare, vector<Key>>;
+
+  template<class Key, class Alloc>
+    flat_set(initializer_list<Key>, Alloc)
+      -> flat_set<Key, less<Key>, vector<Key>>;
+
+  template<class Key, class Compare = less<Key>>
+    flat_set(sorted_unique_t, initializer_list<Key>, Compare = Compare())
+      -> flat_set<Key, Compare, vector<Key>>;
+
+  template<class Key, class Compare, class Alloc>
+    flat_set(sorted_unique_t, initializer_list<Key>, Compare, Alloc)
+      -> flat_set<Key, Compare, vector<Key>>;
+
+  template<class Key, class Alloc>
+    flat_set(sorted_unique_t, initializer_list<Key>, Alloc)
+      -> flat_set<Key, less<Key>, vector<Key>>;
+}
+\end{codeblock}
+
+TODO
+
+\begin{codeblock}
+template <class Key, class Compare = less<Key>, class Container = vector<Key>>
+class flat_multiset {
+  public:
+      // types
+      using key_type                  = Key;
+      using key_compare               = Compare;
+      using value_type                = Key;
+      using value_compare             = Compare;
+      using reference                 = value_type&;
+      using const_reference           = const value_type&;
+      using size_type                 = size_t;
+      using difference_type           = ptrdiff_t;
+      using iterator                  = @\impdefx{type of \tcode{flat_multiset::iterator}}@; // see \ref{container.requirements}
+      using const_iterator            = @\impdefx{type of \tcode{flat_multiset::const_iterator}}@; // see \ref{container.requirements}
+      using reverse_iterator          = std::reverse_iterator<iterator>;
+      using const_reverse_iterator    = std::reverse_iterator<const_iterator>;
+      using container_type            = Container;
+
+      // \ref{flatmultiset.cons}, construct/copy/destroy
+      flat_multiset();
+
+      explicit flat_multiset(container_type);
+      template <class Alloc>
+        flat_multiset(container_type, const Alloc&);
+      flat_multiset(sorted_equivalent_t, container_type);
+      template <class Alloc>
+        flat_multiset(sorted_equivalent_t, container_type, const Alloc&);
+      explicit flat_multiset(const key_compare& comp);
+      template <class Alloc>
+        flat_multiset(const key_compare& comp, const Alloc&);
+      template <class Alloc>
+        explicit flat_multiset(const Alloc&);
+
+      template <class InputIterator>
+        flat_multiset(InputIterator first, InputIterator last,
+                 const key_compare& comp = key_compare());
+      template <class InputIterator, class Alloc>
+        flat_multiset(InputIterator first, InputIterator last,
+                 const key_compare& comp, const Alloc&);
+      template <class InputIterator, class Alloc>
+        flat_multiset(InputIterator first, InputIterator last,
+                 const Alloc& a)
+          : flat_multiset(first, last, key_compare(), a) { }
+
+      template <class InputIterator>
+        flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
+                 const key_compare& comp = key_compare());
+      template <class InputIterator, class Alloc>
+        flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
+                 const key_compare& comp, const Alloc&);
+      template <class InputIterator, class Alloc>
+        flat_multiset(sorted_equivalent_t t, InputIterator first, InputIterator last,
+                 const Alloc& a)
+          : flat_multiset(t, first, last, key_compare(), a) { }
+      template <class Alloc>
+        flat_multiset(flat_multiset, const Alloc&);
+
+      flat_multiset(initializer_list<key_type>, const key_compare& = key_compare());
+      template <class Alloc>
+        flat_multiset(initializer_list<key_type>,
+                 const key_compare&, const Alloc&);
+      template <class Alloc>
+        flat_multiset(initializer_list<key_type> il, const Alloc& a)
+          : flat_multiset(il, key_compare(), a) { }
+
+      flat_multiset(sorted_equivalent_t, initializer_list<key_type>,
+               const key_compare& = key_compare());
+      template <class Alloc>
+        flat_multiset(sorted_equivalent_t, initializer_list<key_type>,
+                 const key_compare&, const Alloc&);
+      template <class Alloc>
+        flat_multiset(sorted_equivalent_t t, initializer_list<key_type> il,
+                 const Alloc& a)
+          : flat_multiset(t, il, key_compare(), a) { }
+
+      flat_multiset& operator=(initializer_list<key_type>);
+
+      // iterators
+      iterator               begin() noexcept;
+      const_iterator         begin() const noexcept;
+      iterator               end() noexcept;
+      const_iterator         end() const noexcept;
+
+      reverse_iterator       rbegin() noexcept;
+      const_reverse_iterator rbegin() const noexcept;
+      reverse_iterator       rend() noexcept;
+      const_reverse_iterator rend() const noexcept;
+
+      const_iterator         cbegin() const noexcept;
+      const_iterator         cend() const noexcept;
+      const_reverse_iterator crbegin() const noexcept;
+      const_reverse_iterator crend() const noexcept;
+
+      // \ref{flatmultiset.capacity}, capacity
+      [[nodiscard]] bool empty() const noexcept;
+      size_type size() const noexcept;
+      size_type max_size() const noexcept;
+
+      // \ref{flatmultiset.modifiers}, modifiers
+      template <class... Args> iterator emplace(Args&&... args);
+      template <class... Args>
+        iterator emplace_hint(const_iterator position, Args&&... args);
+      iterator insert(const value_type& x);
+      iterator insert(value_type&& x);
+      iterator insert(const_iterator position, const value_type& x);
+      iterator insert(const_iterator position, value_type&& x);
+      template <class InputIterator>
+        void insert(InputIterator first, InputIterator last);
+      template <class InputIterator>
+        void insert(sorted_equivalent_t, InputIterator first, InputIterator last);
+      void insert(initializer_list<key_type>);
+      void insert(sorted_equivalent_t, initializer_list<key_type>);
+
+      container_type extract() &&;
+      void replace(container_type&&);
+
+      iterator erase(iterator position);
+      iterator erase(const_iterator position);
+      size_type erase(const key_type& x);
+      iterator erase(const_iterator first, const_iterator last);
+
+      void swap(flat_multiset& fms) noexcept(
+          is_nothrow_swappable_v<container_type> && is_nothrow_swappable_v<key_compare>
+      );
+      void clear() noexcept;
+
+      // observers
+      key_compare key_comp() const;
+      value_compare value_comp() const;
+
+      // set operations
+      iterator find(const key_type& x);
+      const_iterator find(const key_type& x) const;
+      template <class K> iterator find(const K& x);
+      template <class K> const_iterator find(const K& x) const;
+
+      size_type count(const key_type& x) const;
+      template <class K> size_type count(const K& x) const;
+
+      bool contains(const key_type& x) const;
+      template <class K> bool contains(const K& x) const;
+
+      iterator lower_bound(const key_type& x);
+      const_iterator lower_bound(const key_type& x) const;
+      template <class K> iterator lower_bound(const K& x);
+      template <class K> const_iterator lower_bound(const K& x) const;
+
+      iterator upper_bound(const key_type& x);
+      const_iterator upper_bound(const key_type& x) const;
+      template <class K> iterator upper_bound(const K& x);
+      template <class K> const_iterator upper_bound(const K& x) const;
+
+      pair<iterator, iterator> equal_range(const key_type& x);
+      pair<const_iterator, const_iterator> equal_range(const key_type& x) const;
+      template <class K>
+        pair<iterator, iterator> equal_range(const K& x);
+      template <class K>
+        pair<const_iterator, const_iterator> equal_range(const K& x) const;
+  };
+
+  template <class Container>
+    using @\placeholder{cont-value-type}@ = typename Container::value_type; // \expos
+  template<class InputIterator>
+    using @\placeholder{iter-value-type}@ = remove_const_t<
+      typename iterator_traits<InputIterator>::value_type::first_type>;     // \expos
+
+  template <class Container>
+    flat_multiset(Container)
+      -> flat_multiset<@\placeholder{cont-value-type}@<Container>,
+                       less<@\placeholder{cont-value-type}@<Container>>,
+                       vector<@\placeholder{cont-value-type}@<Container>>>;
+
+  template <class Container, class Alloc>
+    flat_multiset(Container, Alloc)
+      -> flat_multiset<@\placeholder{cont-value-type}@<Container>,
+                       less<@\placeholder{cont-value-type}@<Container>>,
+                       vector<@\placeholder{cont-value-type}@<Container>>>;
+
+  template <class Container>
+    flat_multiset(sorted_equivalent_t, Container)
+      -> flat_multiset<@\placeholder{cont-value-type}@<Container>,
+                       less<@\placeholder{cont-value-type}@<Container>>,
+                       vector<@\placeholder{cont-value-type}@<Container>>>;
+
+  template <class Container, class Alloc>
+    flat_multiset(sorted_equivalent_t, Container, Alloc)
+      -> flat_multiset<@\placeholder{cont-value-type}@<Container>,
+                       less<@\placeholder{cont-value-type}@<Container>>,
+                       vector<@\placeholder{cont-value-type}@<Container>>>;
+
+  template <class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
+    flat_multiset(InputIterator, InputIterator, Compare = Compare())
+      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>,
+                       less<@\placeholder{iter-value-type}@<InputIterator>>,
+                       vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+
+  template<class InputIterator, class Compare, class Alloc>
+    flat_multiset(InputIterator, InputIterator, Compare, Alloc)
+      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare,
+                       vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+
+  template<class InputIterator, class Alloc>
+    flat_multiset(InputIterator, InputIterator, Alloc)
+      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>,
+                       less<@\placeholder{iter-value-type}@<InputIterator>>,
+                       vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+
+  template <class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
+    flat_multiset(sorted_equivalent_t, InputIterator, InputIterator, Compare = Compare())
+      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>,
+                       less<@\placeholder{iter-value-type}@<InputIterator>>,
+                       vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+
+  template<class InputIterator, class Compare, class Alloc>
+    flat_multiset(sorted_equivalent_t, InputIterator, InputIterator, Compare, Alloc)
+      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare,
+                       vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+
+  template<class InputIterator, class Alloc>
+    flat_multiset(sorted_equivalent_t, InputIterator, InputIterator, Alloc)
+      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>,
+                       less<@\placeholder{iter-value-type}@<InputIterator>>,
+                       vector<@\placeholder{iter-value-type}@<InputIterator>>>;
+
+  template<class Key, class Compare = less<Key>>
+    flat_multiset(initializer_list<Key>, Compare = Compare())
+      -> flat_multiset<Key, Compare, vector<Key>>;
+
+  template<class Key, class Compare, class Alloc>
+    flat_multiset(initializer_list<Key>, Compare, Alloc)
+      -> flat_multiset<Key, Compare, vector<Key>>;
+
+  template<class Key, class Alloc>
+    flat_multiset(initializer_list<Key>, Alloc)
+      -> flat_multiset<Key, less<Key>, vector<Key>>;
+
+  template<class Key, class Compare = less<Key>>
+  flat_multiset(sorted_equivalent_t, initializer_list<Key>, Compare = Compare())
+      -> flat_multiset<Key, Compare, vector<Key>>;
+
+  template<class Key, class Compare, class Alloc>
+    flat_multiset(sorted_equivalent_t, initializer_list<Key>, Compare, Alloc)
+      -> flat_multiset<Key, Compare, vector<Key>>;
+
+  template<class Key, class Alloc>
+  flat_multiset(sorted_equivalent_t, initializer_list<Key>, Alloc)
+      -> flat_multiset<Key, less<Key>, vector<Key>>;
+}
+\end{codeblock}
+
+TODO
 \end{addedblock}
 
 \rSec1[views]{Views}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10069,30 +10069,30 @@ namespace std {
               mapped_container_type(m.c.values, a)}
         { }
 
-      flat_map(initializer_list<pair<key_type, mapped_type>>&& il,
+      flat_map(initializer_list<value_type>&& il,
                const key_compare& comp = key_compare())
           : flat_map(il, comp) { }
       template <class Alloc>
-        flat_map(initializer_list<pair<key_type, mapped_type>>&& il,
+        flat_map(initializer_list<value_type>&& il,
                  const key_compare& comp, const Alloc& a)
           : flat_map(il, comp, a) { }
       template <class Alloc>
-        flat_map(initializer_list<pair<key_type, mapped_type>>&& il, const Alloc& a)
+        flat_map(initializer_list<value_type>&& il, const Alloc& a)
           : flat_map(il, key_compare(), a) { }
 
-      flat_map(sorted_unique_t s, initializer_list<pair<key_type, mapped_type>>&& il,
+      flat_map(sorted_unique_t s, initializer_list<value_type>&& il,
                const key_compare& comp = key_compare())
           : flat_map(s ,il, comp) { }
       template <class Alloc>
-        flat_map(sorted_unique_t s, initializer_list<pair<key_type, mapped_type>>&& il,
+        flat_map(sorted_unique_t s, initializer_list<value_type>&& il,
                  const key_compare& comp, const Alloc& a)
           : flat_map(s, il, comp, a) { }
       template <class Alloc>
-        flat_map(sorted_unique_t s, initializer_list<pair<key_type, mapped_type>>&& il,
+        flat_map(sorted_unique_t s, initializer_list<value_type>&& il,
                  const Alloc& a)
           : flat_map(s, il, key_compare(), a) { }
 
-      flat_map& operator=(initializer_list<pair<key_type, mapped_type>> il);
+      flat_map& operator=(initializer_list<value_type> il);
 
       // iterators
       iterator                begin() noexcept;
@@ -10136,8 +10136,8 @@ namespace std {
         void insert(InputIterator first, InputIterator last);
       template <class InputIterator>
         void insert(sorted_unique_t, InputIterator first, InputIterator last);
-      void insert(initializer_list<pair<key_type, mapped_type>>);
-      void insert(sorted_unique_t, initializer_list<pair<key_type, mapped_type>> il);
+      void insert(initializer_list<value_type>);
+      void insert(sorted_unique_t, initializer_list<value_type> il);
 
       containers extract() &&;
       void replace(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
@@ -10595,7 +10595,7 @@ no such element is present.
 
 \indexlibrarymember{operator=}{flatmap}%
 \begin{itemdecl}
-flat_map& operator=(initializer_list<pair<key_type, mapped_type>> il);
+flat_map& operator=(initializer_list<value_type> il);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10834,7 +10834,7 @@ to \tcode{compare}.
 
 \indexlibrarymember{flatmap}{insert}%
 \begin{itemdecl}
-void insert(sorted_unique_t, initializer_list<pair<key_type, mapped_type>> il);
+void insert(sorted_unique_t, initializer_list<value_type> il);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11157,30 +11157,30 @@ namespace std {
           , c{key_container_type(m.c.keys, a), mapped_container_type(m.c.values, a)}
         { }
 
-      flat_multimap(initializer_list<pair<key_type, mapped_type>>&& il,
+      flat_multimap(initializer_list<value_type>&& il,
                     const key_compare& comp = key_compare())
           : flat_multimap(il, comp) { }
       template <class Alloc>
-        flat_multimap(initializer_list<pair<key_type, mapped_type>>&& il,
+        flat_multimap(initializer_list<value_type>&& il,
                       const key_compare& comp, const Alloc& a)
           : flat_multimap(il, comp, a) { }
       template <class Alloc>
-        flat_multimap(initializer_list<pair<key_type, mapped_type>>&& il, const Alloc& a)
+        flat_multimap(initializer_list<value_type>&& il, const Alloc& a)
           : flat_multimap(il, key_compare(), a) { }
 
-      flat_multimap(sorted_equivalent_t s, initializer_list<pair<key_type, mapped_type>>&& il,
+      flat_multimap(sorted_equivalent_t s, initializer_list<value_type>&& il,
                     const key_compare& comp = key_compare())
           : flat_multimap(s, il, comp) { }
       template <class Alloc>
-        flat_multimap(sorted_equivalent_t s, initializer_list<pair<key_type, mapped_type>>&& il,
+        flat_multimap(sorted_equivalent_t s, initializer_list<value_type>&& il,
                       const key_compare& comp, const Alloc& a)
           : flat_multimap(s, il, comp, a) { }
       template <class Alloc>
-        flat_multimap(sorted_equivalent_t s, initializer_list<pair<key_type, mapped_type>>&& il,
+        flat_multimap(sorted_equivalent_t s, initializer_list<value_type>&& il,
                       const Alloc& a)
           : flat_multimap(s, il, key_compare(), a) { }
 
-      flat_multimap& operator=(initializer_list<pair<key_type, mapped_type>> il);
+      flat_multimap& operator=(initializer_list<value_type> il);
 
       // iterators
       iterator                begin() noexcept;
@@ -11218,8 +11218,8 @@ namespace std {
         void insert(InputIterator first, InputIterator last);
       template <class InputIterator>
         void insert(sorted_equivalent_t, InputIterator first, InputIterator last);
-      void insert(initializer_list<pair<key_type, mapped_type>>);
-      void insert(sorted_equivalent_t, initializer_list<pair<key_type, mapped_type>> il);
+      void insert(initializer_list<value_type>);
+      void insert(sorted_equivalent_t, initializer_list<value_type> il);
 
       containers extract() &&;
       void replace(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
@@ -11577,7 +11577,7 @@ Linear.
 
 \indexlibrarymember{operator=}{flatmap}%
 \begin{itemdecl}
-flat_map& operator=(initializer_list<pair<key_type, mapped_type>> il);
+flat_map& operator=(initializer_list<value_type> il);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11662,7 +11662,7 @@ to \tcode{compare}.
 
 \indexlibrarymember{flatmultimap}{insert}%
 \begin{itemdecl}
-void insert(sorted_unique_t, initializer_list<pair<key_type, mapped_type>> il);
+void insert(sorted_unique_t, initializer_list<value_type> il);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10166,17 +10166,6 @@ namespace std {
       void swap(flat_map& fm) noexcept;
       void clear() noexcept;
 
-      template<class C2>
-        void merge(flat_map<key_type, mapped_type, C2, key_container_type, mapped_container_type>& source);
-      template<class C2>
-        void merge(flat_map<key_type, mapped_type, C2, key_container_type, mapped_container_type>&& source);
-      template<class C2>
-        void merge(
-          flat_map<key_type, mapped_type, C2, key_container_type, mapped_container_type>& source);
-      template<class C2>
-        void merge(
-          flat_map<key_type, mapped_type, C2, key_container_type, mapped_container_type>&& source);
-
       // observers
       key_compare key_comp() const;
       value_compare value_comp() const;
@@ -11221,15 +11210,6 @@ namespace std {
 
       void swap(flat_multimap& fm) noexcept;
       void clear() noexcept;
-
-      template<class C2>
-        void merge(flat_multimap<key_type, mapped_type, C2, key_container_type, mapped_container_type>& source);
-      template<class C2>
-        void merge(flat_multimap<key_type, mapped_type, C2, key_container_type, mapped_container_type>&& source);
-      template<class C2>
-        void merge(flat_map<key_type, mapped_type, C2, key_container_type, mapped_container_type>& source);
-      template<class C2>
-        void merge(flat_map<key_type, mapped_type, C2, key_container_type, mapped_container_type>&& source);
 
       // observers
       key_compare key_comp() const;

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -8950,6 +8950,18 @@ adaptor's \tcode{Container}, \tcode{KeyContainer}, \tcode{MappedContainer}, or
 \tcode{Compare} object (if any).
 \end{addedblock}
 
+\begin{addedblock}
+\pnum
+For container adaptors that have them, the \tcode{insert}, \tcode{emplace},
+and \tcode{erase} members shall affect the validity of iterators and
+references to the adaptor's container(s) in the same way that the containers'
+respective \tcode{insert}, \tcode{emplace}, and \tcode{erase} members do.
+\begin{example}
+A call to \tcode{flat_map<Key, T>::insert} invalidates all iterators to
+the \tcode{flat_map}.
+\end{example}
+\end{addedblock}
+
 \pnum
 A deduction guide for a container adaptor shall not participate in overload resolution if any of the following are true:
 \begin{itemize}
@@ -9917,8 +9929,9 @@ on the keys. The \tcode{flat_map} class supports random access iterators.
 A \tcode{flat_map} satisfies all of the requirements of a container, of a
 reversible container\iref{container.requirements}, and of an associative
 container\iref{associative.reqmts}, except for the requirements related to
-node handles\iref{container.node}.  A \tcode{flat_map} does not meet the
-additional requirements of an allocator-aware container, as described in
+node handles\iref{container.node} and iterator
+invalidation\iref{containers.associative.requirements}.  A \tcode{flat_map}
+does not meet the additional requirements of an allocator-aware container,
 \tref{containers.allocatoraware}.
 
 \pnum
@@ -10952,8 +10965,10 @@ the keys. The \tcode{flat_multimap} class supports random access iterators.
 A \tcode{flat_multimap} satisfies all of the requirements of a container, of a
 reversible container\iref{container.requirements}, and of an associative
 container\iref{associative.reqmts}, except for the requirements related to
-node handles\iref{container.node}.  A \tcode{flat_multimap} does not meet the
-additional requirements of an allocator-aware container, as described in
+node handles\iref{container.node} and iterator
+invalidation\iref{containers.associative.requirements}.
+A \tcode{flat_multimap} does not meet the additional requirements of an
+allocator-aware container, as described in
 \tref{containers.allocatoraware}.
 
 \pnum

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -12033,9 +12033,7 @@ namespace std {
     size_type erase(const key_type& x);
     iterator erase(const_iterator first, const_iterator last);
 
-    void swap(flat_set& fs) noexcept(
-      is_nothrow_swappable_v<container_type> && is_nothrow_swappable_v<key_compare>
-    );
+    void swap(flat_set& fs) noexcept;
     void clear() noexcept;
 
     // observers
@@ -12287,7 +12285,205 @@ Linear.
 
 \rSec3[flatset.modifiers]{Modifiers}
 
-TODO
+\indexlibrarymember{operator=}{flatset}%
+\begin{itemdecl}
+flat_set& operator=(initializer_list<value_type> il);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Equivalent to:
+\begin{codeblock}
+clear();
+insert(il);
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibrarymember{emplace}{flatset}%
+\begin{itemdecl}
+template <class... Args> pair<iterator, bool> emplace(Args&&... args);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \constraints \tcode{key_type(std::forward<Args>(args)...)} is well-formed.
+
+\pnum
+\effects
+First, constructs a \tcode{key_type} object \tcode{t} constructed
+with \tcode{std::forward<Args>(args)...}.  If the set already contains an
+element whose key is equivalent to \tcode{t}, there is no effect.  Otherwise,
+equivalent to:
+\begin{codeblock}
+auto it = lower_bound(c.begin(), c.end(), t);
+c.emplace(it, std::move(t));
+\end{codeblock}
+
+\pnum
+\returns
+The \tcode{bool} component of the returned pair is \tcode{true} if and only if
+the insertion took place, and the iterator component of the pair points to the
+element with key equivalent to the key of \tcode{t}.
+\end{itemdescr}
+
+\indexlibrarymember{flatset}{insert}%
+\begin{itemdecl}
+template <class InputIterator>
+  void insert(sorted_unique_t, InputIterator first, InputIterator last);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \expects
+The range \range{first}{last} is sorted with respect to \tcode{compare}.
+
+\pnum \effects Equivalent to: \tcode{insert(first, last)}.
+
+\pnum \complexity Linear.
+\end{itemdescr}
+
+\indexlibrarymember{flatset}{insert}%
+\begin{itemdecl}
+void insert(sorted_unique_t, initializer_list<value_type> il);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \effects Equivalent to \tcode{insert(sorted_unique_t{}, il.begin(), il.end())}.
+\end{itemdescr}
+
+\indexlibrarymember{flatset}{swap}%
+\begin{itemdecl}
+void swap(flat_set& fs) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \constraints \tcode{is_nothrow_swappable_v<container_type> \&\&
+is_nothrow_swappable_v<key_compare>}
+
+\pnum \effects Equivalent to:
+\begin{codeblock}
+using std::swap;
+swap(c, fs.c);
+swap(c.compare, fs.compare);
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibrarymember{flatset}{extract}%
+\begin{itemdecl}
+container_type extract() &&;
+\end{itemdecl}
+
+\begin{itemdescr}
+\effects Equivalent to:
+\begin{codeblock}
+container_type temp;
+temp.swap(c);
+return temp;
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibrarymember{flatset}{replace}%
+\begin{itemdecl}
+void replace(container_type&& cont);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \expects
+The elements of \tcode{cont} are sorted with respect to \tcode{compare}.
+
+\pnum
+\effects Equivalent to:
+\begin{codeblock}
+c = std::move(cont);
+\end{codeblock}
+\end{itemdescr}
+
+\rSec3[flatset.ops]{Operators}
+
+\indexlibrary{\idxcode{operator==}!\idxcode{flatset}}%
+\begin{itemdecl}
+template<class Key, class Compare, class Container>
+  bool operator==(const flat_set<Key, Compare, Container>& x,
+                  const flat_set<Key, Compare, Container>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Equivalent to:
+\tcode{return std::equal(x.begin(), x.end(), y.begin(), y.end());}
+\end{itemdescr}
+
+\indexlibrary{\idxcode{operator!=}!\idxcode{flatset}}%
+\begin{itemdecl}
+template<class Key, class Compare, class Container>
+  bool operator!=(const flat_set<Key, Compare, Container>& x,
+                  const flat_set<Key, Compare, Container>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \returns \tcode{!(x == y)}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{operator<}!\idxcode{flatset}}%
+\begin{itemdecl}
+template<class Key, class Compare, class Container>
+  bool operator< (const flat_set<Key, Compare, Container>& x,
+                  const flat_set<Key, Compare, Container>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Equivalent to:
+\tcode{return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());}
+\end{itemdescr}
+
+\indexlibrary{\idxcode{operator>}!\idxcode{flatset}}%
+\begin{itemdecl}
+template<class Key, class Compare, class Container>
+  bool operator> (const flat_set<Key, Compare, Container>& x,
+                  const flat_set<Key, Compare, Container>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \returns \tcode{y < x}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{operator<=}!\idxcode{flatset}}%
+\begin{itemdecl}
+template<class Key, class Compare, class Container>
+  bool operator<=(const flat_set<Key, Compare, Container>& x,
+                  const flat_set<Key, Compare, Container>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \returns \tcode{!(y < x)}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{operator>=}!\idxcode{flatset}}%
+\begin{itemdecl}
+template<class Key, class Compare, class Container>
+  bool operator>=(const flat_set<Key, Compare, Container>& x,
+                  const flat_set<Key, Compare, Container>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \returns \tcode{!(x < y)}.
+\end{itemdescr}
+
+\rSec3[flatset.special]{Specialized algorithms}
+
+\indexlibrarymember{swap}{flatset}%
+\begin{itemdecl}
+template<class Key, class Compare, class Container>
+  void swap(flat_set<Key, Compare, Container>& x,
+            flat_set<Key, Compare, Container>& y) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \constraints \tcode{is_nothrow_swappable_v<Container> \&\&
+is_nothrow_swappable_v<Compare>}
+
+\pnum
+\effects Equivalent to: \tcode{x.swap(y)}.
+\end{itemdescr}
 
 \rSec2[flatmultiset]{Class template \tcode{flat_multiset}}
 
@@ -12508,9 +12704,7 @@ class flat_multiset {
     size_type erase(const key_type& x);
     iterator erase(const_iterator first, const_iterator last);
 
-    void swap(flat_multiset& fms) noexcept(
-        is_nothrow_swappable_v<container_type> && is_nothrow_swappable_v<key_compare>
-    );
+    void swap(flat_multiset& fms) noexcept;
     void clear() noexcept;
 
     // observers
@@ -12764,7 +12958,201 @@ Linear.
 
 \rSec3[flatmultiset.modifiers]{Modifiers}
 
-TODO
+\indexlibrarymember{operator=}{flatmultiset}%
+\begin{itemdecl}
+flat_multiset& operator=(initializer_list<value_type> il);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Equivalent to:
+\begin{codeblock}
+clear();
+insert(il);
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibrarymember{emplace}{flatmultiset}%
+\begin{itemdecl}
+template <class... Args> iterator emplace(Args&&... args);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \constraints \tcode{key_type(std::forward<Args>(args)...)} is well-formed.
+
+\pnum
+\effects
+First, constructs a \tcode{key_type} object \tcode{t} constructed
+with \tcode{std::forward<Args>(args)...}, then inserts \tcode{t} as if by:
+\begin{codeblock}
+auto it = upper_bound(c.begin(), c.end(), t);
+c.emplace(it, std::move(t));
+\end{codeblock}
+
+\pnum
+\returns
+An iterator that points to the inserted element.
+\end{itemdescr}
+
+\indexlibrarymember{flatmultiset}{insert}%
+\begin{itemdecl}
+template <class InputIterator>
+  void insert(sorted_unique_t, InputIterator first, InputIterator last);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \expects
+The range \range{first}{last} is sorted with respect to \tcode{compare}.
+
+\pnum \effects Equivalent to: \tcode{insert(first, last)}.
+
+\pnum \complexity Linear.
+\end{itemdescr}
+
+\indexlibrarymember{flatmultiset}{insert}%
+\begin{itemdecl}
+void insert(sorted_unique_t, initializer_list<value_type> il);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \effects Equivalent to \tcode{insert(sorted_unique_t{}, il.begin(), il.end())}.
+\end{itemdescr}
+
+\indexlibrarymember{flatmultiset}{swap}%
+\begin{itemdecl}
+void swap(flat_multiset& fms) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \constraints \tcode{is_nothrow_swappable_v<container_type> \&\&
+is_nothrow_swappable_v<key_compare>}
+
+\pnum \effects Equivalent to:
+\begin{codeblock}
+using std::swap;
+swap(c, fms.c);
+swap(c.compare, fms.compare);
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibrarymember{flatmultiset}{extract}%
+\begin{itemdecl}
+container_type extract() &&;
+\end{itemdecl}
+
+\begin{itemdescr}
+\effects Equivalent to:
+\begin{codeblock}
+container_type temp;
+temp.swap(c);
+return temp;
+\end{codeblock}
+\end{itemdescr}
+
+\indexlibrarymember{flatmultiset}{replace}%
+\begin{itemdecl}
+void replace(container_type&& cont);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \expects
+The elements of \tcode{cont} are sorted with respect to \tcode{compare}.
+
+\pnum
+\effects Equivalent to:
+\begin{codeblock}
+c = std::move(cont);
+\end{codeblock}
+\end{itemdescr}
+
+\rSec3[flatmultiset.ops]{Operators}
+
+\indexlibrary{\idxcode{operator==}!\idxcode{flatmultiset}}%
+\begin{itemdecl}
+template<class Key, class Compare, class Container>
+  bool operator==(const flat_multiset<Key, Compare, Container>& x,
+                  const flat_multiset<Key, Compare, Container>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Equivalent to:
+\tcode{return std::equal(x.begin(), x.end(), y.begin(), y.end());}
+\end{itemdescr}
+
+\indexlibrary{\idxcode{operator!=}!\idxcode{flatmultiset}}%
+\begin{itemdecl}
+template<class Key, class Compare, class Container>
+  bool operator!=(const flat_multiset<Key, Compare, Container>& x,
+                  const flat_multiset<Key, Compare, Container>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \returns \tcode{!(x == y)}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{operator<}!\idxcode{flatmultiset}}%
+\begin{itemdecl}
+template<class Key, class Compare, class Container>
+  bool operator< (const flat_multiset<Key, Compare, Container>& x,
+                  const flat_multiset<Key, Compare, Container>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Equivalent to:
+\tcode{return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());}
+\end{itemdescr}
+
+\indexlibrary{\idxcode{operator>}!\idxcode{flatmultiset}}%
+\begin{itemdecl}
+template<class Key, class Compare, class Container>
+  bool operator> (const flat_multiset<Key, Compare, Container>& x,
+                  const flat_multiset<Key, Compare, Container>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \returns \tcode{y < x}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{operator<=}!\idxcode{flatmultiset}}%
+\begin{itemdecl}
+template<class Key, class Compare, class Container>
+  bool operator<=(const flat_multiset<Key, Compare, Container>& x,
+                  const flat_multiset<Key, Compare, Container>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \returns \tcode{!(y < x)}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{operator>=}!\idxcode{flatmultiset}}%
+\begin{itemdecl}
+template<class Key, class Compare, class Container>
+  bool operator>=(const flat_multiset<Key, Compare, Container>& x,
+                  const flat_multiset<Key, Compare, Container>& y);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \returns \tcode{!(x < y)}.
+\end{itemdescr}
+
+\rSec3[flatmultiset.special]{Specialized algorithms}
+
+\indexlibrarymember{swap}{flatmultiset}%
+\begin{itemdecl}
+template<class Key, class Compare, class Container>
+  void swap(flat_multiset<Key, Compare, Container>& x,
+            flat_multiset<Key, Compare, Container>& y) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum \constraints \tcode{is_nothrow_swappable_v<Container> \&\&
+is_nothrow_swappable_v<Compare>}
+
+\pnum
+\effects Equivalent to: \tcode{x.swap(y)}.
+\end{itemdescr}
 \end{addedblock}
 
 \rSec1[views]{Views}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10591,10 +10591,9 @@ template <class... Args> pair<iterator, bool> emplace(Args&&... args);
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{value_type} shall be contructible from \tcode{args...}, so that the
-following expression is well-formed: \tcode{pair<key_type,
-  mapped_type>(std::forward<Args>(args)...)}.
+\constraints
+The \tcode{pair<key_type, mapped_type>(std::forward<Args>(args)...)} is
+well-formed.
 
 \pnum
 \effects
@@ -10646,10 +10645,9 @@ template<class... Args>
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{mapped_type} shall be contructible from \tcode{args...}, so that the
-following expression is well-formed:
-\tcode{mapped_type(std::forward<Args>(args)...)}.
+\constraints
+The expression \tcode{mapped_type(std::forward<Args>(args)...)} is
+well-formed.
 
 \pnum
 \effects
@@ -10684,10 +10682,9 @@ template<class... Args>
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{mapped_type} shall be contructible from \tcode{args...}, so that the
-following expression is well-formed:
-\tcode{mapped_type(std::forward<Args>(args)...)}.
+\constraints
+The expression \tcode{mapped_type(std::forward<Args>(args)...)} is
+well-formed.
 
 \pnum
 \effects
@@ -10724,11 +10721,9 @@ template<class M>
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{is_assignable_v<mapped_type\&, M>} shall be \tcode{true}.
-\tcode{mapped_type} shall be contructible from \tcode{obj}, so that the
-following expression is well-formed:
-\tcode{mapped_type(std::forward<Args>(obj))}.
+\constraints
+\tcode{is_assignable_v<mapped_type\&, M>}, and the expresion
+\tcode{mapped_type(std::forward<M>(obj))} is well-formed.
 
 \pnum
 \effects
@@ -10762,11 +10757,9 @@ template<class M>
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{is_assignable_v<mapped_type\&, M>} shall be \tcode{true}.
-\tcode{mapped_type} shall be contructible from \tcode{obj}, so that the
-following expression is well-formed:
-\tcode{mapped_type(std::forward<Args>(obj))}.
+\constraints
+\tcode{is_assignable_v<mapped_type\&, M>}, and the expression
+\tcode{mapped_type(std::forward<M>(obj))} is well-formed.
 
 \pnum
 \effects
@@ -10797,8 +10790,8 @@ template <class InputIterator>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \requires The range \range{first}{last} shall be sorted with respect
-to \tcode{compare}.
+\pnum \expects
+The range \range{first}{last} is sorted with respect to \tcode{compare}.
 
 \pnum \effects Equivalent to: \tcode{insert(first, last)}.
 
@@ -10859,8 +10852,9 @@ void replace(key_container_type&& key_cont, mapped_container_type&& mapped_cont)
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \requires \tcode{key_cont.size() == mapped_cont.size()}, and that
-the elements of \tcode{key_cont} are sorted with respect to \tcode{compare}.
+\pnum \expects
+\tcode{key_cont.size() == mapped_cont.size()}, and the elements of
+\tcode{key_cont} are sorted with respect to \tcode{compare}.
 
 \pnum
 \effects Equivalent to:
@@ -11552,10 +11546,8 @@ template <class... Args> pair<iterator, bool> emplace(Args&&... args);
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{value_type} shall be contructible from \tcode{args...}, so that the
-following expression is well-formed:
-\tcode{value_type(std::forward<Args>(args)...)}.
+\constraints
+The expression \tcode{value_type(std::forward<Args>(args)...)} is well-formed.
 
 \pnum
 \effects
@@ -11604,8 +11596,8 @@ template <class InputIterator>
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \requires The range \range{first}{last} shall be sorted with respect
-to \tcode{compare}.
+\pnum \expects
+The range \range{first}{last} is sorted with respect to \tcode{compare}.
 
 \pnum \effects Equivalent to: \tcode{insert(first, last)}.
 
@@ -11631,10 +11623,9 @@ template<class... Args>
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{mapped_type} shall be contructible from \tcode{args...}, so that the
-following expression is well-formed:
-\tcode{mapped_type(std::forward<Args>(args)...)}.
+\constraints
+The expression \tcode{mapped_type(std::forward<Args>(args)...)} is
+well-formed.
 
 \pnum
 \effects
@@ -11669,10 +11660,9 @@ template<class... Args>
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{mapped_type} shall be contructible from \tcode{args...}, so that the
-following expression is well-formed:
-\tcode{mapped_type(std::forward<Args>(args)...)}.
+\constraints
+The expression \tcode{mapped_type(std::forward<Args>(args)...)} is
+well-formed.
 
 \pnum
 \effects
@@ -11743,8 +11733,9 @@ void replace(key_container_type&& key_cont, mapped_container_type&& mapped_cont)
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum \requires \tcode{key_cont.size() == mapped_cont.size()}, and that
-the elements of \tcode{key_cont} are sorted with respect to \tcode{compare}.
+\pnum \expects
+\tcode{key_cont.size() == mapped_cont.size()}, and the elements of
+\tcode{key_cont} are sorted with respect to \tcode{compare}.
 
 \pnum
 \effects Equivalent to:

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9011,7 +9011,7 @@ namespace std {
 #include <initializer_list>
 
 namespace std {
-  // \ref{flatmap}, class template \tcode{flatmap}
+  // \ref{flatmap}, class template \tcode{flat_map}
   template<class Key, class T, class Compare = less<Key>,
            class KeyContainer = vector<Key>, class MappedContainer = vector<T>>
     class flat_map;

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10031,7 +10031,7 @@ that contains equal elements, is undefined.
 
 \pnum
 Constructors that take an \tcode{Alloc} argument shall participate in overload
-resolution only if \tcode{uses_allocator_v<key_container_type, Alloc> ||
+resolution only if \tcode{uses_allocator_v<key_container_type, Alloc> \&\&
   uses_allocator_v<mapped_container_type, Alloc>} is \tcode{true}.
 
 \pnum
@@ -11054,7 +11054,7 @@ to \tcode{key_compare} is undefined.
 
 \pnum
 Constructors that take an \tcode{Alloc} argument shall participate in overload
-resolution only if \tcode{uses_allocator_v<key_container_type, Alloc> ||
+resolution only if \tcode{uses_allocator_v<key_container_type, Alloc> \&\&
   uses_allocator_v<mapped_container_type, Alloc>} is \tcode{true}.
 
 \pnum

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10216,17 +10216,23 @@ namespace std {
 
   template<class Container>
     using @\placeholder{cont-key-type}@ =
-      remove_const_t<typename Container::value_type::first_type>;   // \expos
+      remove_const_t<typename Container::value_type::first_type>;         // \expos
   template<class Container>
-    using @\placeholder{cont-val-type}@ =
-      typename Container::value_type::second_type;                  // \expos
+    using @\placeholder{cont-mapped-type}@ =
+      typename Container::value_type::second_type;                        // \expos
+  template<class InputIterator>
+    using @\placeholder{iter-key-type}@ = remove_const_t<
+      typename iterator_traits<InputIterator>::value_type::first_type>;   // \expos
+  template<class InputIterator>
+    using @\placeholder{iter-mapped-type}@ =
+      typename iterator_traits<InputIterator>::value_type::second_type;   // \expos
 
   template <class Container>
     flat_map(Container)
-      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-val-type}@<Container>,
+      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>,
                   less<@\placeholder{cont-key-type}@<Container>>,
                   vector<@\placeholder{cont-key-type}@<Container>>,
-                  vector<@\placeholder{cont-val-type}@<Container>>>;
+                  vector<@\placeholder{cont-mapped-type}@<Container>>>;
 
   template <class KeyContainer, class MappedContainer>
     flat_map(KeyContainer, MappedContainer)
@@ -10237,10 +10243,10 @@ namespace std {
 
   template <class Container, class Alloc>
     flat_map(Container, Alloc)
-      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-val-type}@<Container>,
+      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>,
                   less<@\placeholder{cont-key-type}@<Container>>,
                   vector<@\placeholder{cont-key-type}@<Container>>,
-                  vector<@\placeholder{cont-val-type}@<Container>>>;
+                  vector<@\placeholder{cont-mapped-type}@<Container>>>;
 
   template <class KeyContainer, class MappedContainer, class Alloc>
     flat_map(KeyContainer, MappedContainer, Alloc)
@@ -10251,10 +10257,10 @@ namespace std {
 
   template <class Container>
     flat_map(sorted_unique_t, Container)
-      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-val-type}@<Container>,
+      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>,
                   less<@\placeholder{cont-key-type}@<Container>>,
                   vector<@\placeholder{cont-key-type}@<Container>>,
-                  vector<@\placeholder{cont-val-type}@<Container>>>;
+                  vector<@\placeholder{cont-mapped-type}@<Container>>>;
 
   template <class KeyContainer, class MappedContainer>
     flat_map(sorted_unique_t, KeyContainer, MappedContainer)
@@ -10265,10 +10271,10 @@ namespace std {
 
   template <class Container, class Alloc>
     flat_map(sorted_unique_t, Container, Alloc)
-      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-val-type}@<Container>,
+      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>,
                   less<@\placeholder{cont-key-type}@<Container>>,
                   vector<@\placeholder{cont-key-type}@<Container>>,
-                  vector<@\placeholder{cont-val-type}@<Container>>>;
+                  vector<@\placeholder{cont-mapped-type}@<Container>>>;
 
   template <class KeyContainer, class MappedContainer, class Alloc>
     flat_map(sorted_unique_t, KeyContainer, MappedContainer, Alloc)
@@ -10279,43 +10285,43 @@ namespace std {
 
   template <class InputIterator, class Compare = less<iter_key_t<InputIterator>>>
     flat_map(InputIterator, InputIterator, Compare = Compare())
-      -> flat_map<iter_key_t<InputIterator>, iter_val_t<InputIterator>,
+      -> flat_map<iter_key_t<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
                   less<iter_key_t<InputIterator>>,
                   vector<iter_key_t<InputIterator>>,
-                  vector<iter_val_t<InputIterator>>>;
+                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
   template<class InputIterator, class Compare, class Alloc>
     flat_map(InputIterator, InputIterator, Compare, Alloc)
-      -> flat_map<iter_key_t<InputIterator>, iter_val_t<InputIterator>, Compare,
+      -> flat_map<iter_key_t<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare,
                   vector<iter_key_t<InputIterator>>,
-                  vector<iter_val_t<InputIterator>>>;
+                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
   template<class InputIterator, class Alloc>
     flat_map(InputIterator, InputIterator, Alloc)
-      -> flat_map<iter_key_t<InputIterator>, iter_val_t<InputIterator>,
+      -> flat_map<iter_key_t<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
                   less<iter_key_t<InputIterator>>,
                   vector<iter_key_t<InputIterator>>,
-                  vector<iter_val_t<InputIterator>>>;
+                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
   template <class InputIterator, class Compare = less<iter_key_t<InputIterator>>>
     flat_map(sorted_unique_t, InputIterator, InputIterator, Compare = Compare())
-      -> flat_map<iter_key_t<InputIterator>, iter_val_t<InputIterator>,
+      -> flat_map<iter_key_t<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
                   less<iter_key_t<InputIterator>>,
                   vector<iter_key_t<InputIterator>>,
-                  vector<iter_val_t<InputIterator>>>;
+                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
   template<class InputIterator, class Compare, class Alloc>
     flat_map(sorted_unique_t, InputIterator, InputIterator, Compare, Alloc)
-      -> flat_map<iter_key_t<InputIterator>, iter_val_t<InputIterator>, Compare,
+      -> flat_map<iter_key_t<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare,
                   vector<iter_key_t<InputIterator>>,
-                  vector<iter_val_t<InputIterator>>>;
+                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
   template<class InputIterator, class Alloc>
     flat_map(sorted_unique_t, InputIterator, InputIterator, Alloc)
-      -> flat_map<iter_key_t<InputIterator>, iter_val_t<InputIterator>,
+      -> flat_map<iter_key_t<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
                   less<iter_key_t<InputIterator>>,
                   vector<iter_key_t<InputIterator>>,
-                  vector<iter_val_t<InputIterator>>>;
+                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
   template<class Key, class T, class Compare = less<Key>>
     flat_map(initializer_list<pair<Key, T>>, Compare = Compare())
@@ -11252,17 +11258,23 @@ namespace std {
 
   template<class Container>
     using @\placeholder{cont-key-type}@ =
-      remove_const_t<typename Container::value_type::first_type>;   // \expos
+      remove_const_t<typename Container::value_type::first_type>;          // \expos
   template<class Container>
-    using @\placeholder{cont-val-type}@ =
-      typename Container::value_type::second_type;                  // \expos
+    using @\placeholder{cont-mapped-type}@ =
+      typename Container::value_type::second_type;                        // \expos
+  template<class InputIterator>
+    using @\placeholder{iter-key-type}@ = remove_const_t<
+      typename iterator_traits<InputIterator>::value_type::first_type>;   // \expos
+  template<class InputIterator>
+    using @\placeholder{iter-mapped-type}@ =
+      typename iterator_traits<InputIterator>::value_type::second_type;   // \expos
 
   template <class Container>
     flat_multimap(Container)
-      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-val-type}@<Container>,
+      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>,
                        less<@\placeholder{cont-key-type}@<Container>>,
                        vector<@\placeholder{cont-key-type}@<Container>>,
-                       vector<@\placeholder{cont-val-type}@<Container>>>;
+                       vector<@\placeholder{cont-mapped-type}@<Container>>>;
 
   template <class KeyContainer, class MappedContainer>
     flat_multimap(KeyContainer, MappedContainer)
@@ -11273,10 +11285,10 @@ namespace std {
 
   template <class Container, class Alloc>
     flat_multimap(Container, Alloc)
-      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-val-type}@<Container>,
+      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>,
                        less<@\placeholder{cont-key-type}@<Container>>,
                        vector<@\placeholder{cont-key-type}@<Container>>,
-                       vector<@\placeholder{cont-val-type}@<Container>>>;
+                       vector<@\placeholder{cont-mapped-type}@<Container>>>;
 
   template <class KeyContainer, class MappedContainer, class Alloc>
     flat_multimap(KeyContainer, MappedContainer, Alloc)
@@ -11287,10 +11299,10 @@ namespace std {
 
   template <class Container>
     flat_multimap(sorted_equivalent_t, Container)
-      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-val-type}@<Container>,
+      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>,
                        less<@\placeholder{cont-key-type}@<Container>>,
                        vector<@\placeholder{cont-key-type}@<Container>>,
-                       vector<@\placeholder{cont-val-type}@<Container>>>;
+                       vector<@\placeholder{cont-mapped-type}@<Container>>>;
 
   template <class KeyContainer, class MappedContainer>
     flat_multimap(sorted_equivalent_t, KeyContainer, MappedContainer)
@@ -11301,10 +11313,10 @@ namespace std {
 
   template <class Container, class Alloc>
     flat_multimap(sorted_equivalent_t, Container, Alloc)
-      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-val-type}@<Container>,
+      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>,
                        less<@\placeholder{cont-key-type}@<Container>>,
                        vector<@\placeholder{cont-key-type}@<Container>>,
-                       vector<@\placeholder{cont-val-type}@<Container>>>;
+                       vector<@\placeholder{cont-mapped-type}@<Container>>>;
 
   template <class KeyContainer, class MappedContainer, class Alloc>
     flat_multimap(sorted_equivalent_t, KeyContainer, MappedContainer, Alloc)
@@ -11313,46 +11325,46 @@ namespace std {
                        less<typename KeyContainer::value_type>,
                        KeyContainer, MappedContainer>;
 
-  template <class InputIterator, class Compare = less<iter_key_t<InputIterator>>>
+  template <class InputIterator, class Compare = less<@\placeholder{iter-key-type}@<InputIterator>>>
     flat_multimap(InputIterator, InputIterator, Compare = Compare())
-      -> flat_multimap<iter_key_t<InputIterator>, iter_val_t<InputIterator>,
-                       less<iter_key_t<InputIterator>>,
-                       vector<iter_key_t<InputIterator>>,
-                       vector<iter_val_t<InputIterator>>>;
+      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
+                       less<@\placeholder{iter-key-type}@<InputIterator>>,
+                       vector<@\placeholder{iter-key-type}@<InputIterator>>,
+                       vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
   template<class InputIterator, class Compare, class Alloc>
     flat_multimap(InputIterator, InputIterator, Compare, Alloc)
-      -> flat_multimap<iter_key_t<InputIterator>, iter_val_t<InputIterator>,
-                       Compare, vector<iter_key_t<InputIterator>>,
-                       vector<iter_val_t<InputIterator>>>;
+      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
+                       Compare, vector<@\placeholder{iter-key-type}@<InputIterator>>,
+                       vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
   template<class InputIterator, class Alloc>
     flat_multimap(InputIterator, InputIterator, Alloc)
-      -> flat_multimap<iter_key_t<InputIterator>, iter_val_t<InputIterator>,
-                       less<iter_key_t<InputIterator>>,
-                       vector<iter_key_t<InputIterator>>,
-                       vector<iter_val_t<InputIterator>>>;
+      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
+                       less<@\placeholder{iter-key-type}@<InputIterator>>,
+                       vector<@\placeholder{iter-key-type}@<InputIterator>>,
+                       vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
-  template <class InputIterator, class Compare = less<iter_key_t<InputIterator>>>
+  template <class InputIterator, class Compare = less<@\placeholder{iter-key-type}@<InputIterator>>>
     flat_multimap(sorted_equivalent_t, InputIterator, InputIterator,
                   Compare = Compare())
-      -> flat_multimap<iter_key_t<InputIterator>, iter_val_t<InputIterator>,
-                       less<iter_key_t<InputIterator>>,
-                       vector<iter_key_t<InputIterator>>,
-                       vector<iter_val_t<InputIterator>>>;
+      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
+                       less<@\placeholder{iter-key-type}@<InputIterator>>,
+                       vector<@\placeholder{iter-key-type}@<InputIterator>>,
+                       vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
   template<class InputIterator, class Compare, class Alloc>
     flat_multimap(sorted_equivalent_t, InputIterator, InputIterator, Compare, Alloc)
-      -> flat_multimap<iter_key_t<InputIterator>, iter_val_t<InputIterator>,
-                       Compare, vector<iter_key_t<InputIterator>>,
-                       vector<iter_val_t<InputIterator>>>;
+      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
+                       Compare, vector<@\placeholder{iter-key-type}@<InputIterator>>,
+                       vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
   template<class InputIterator, class Alloc>
     flat_multimap(sorted_equivalent_t, InputIterator, InputIterator, Alloc)
-      -> flat_multimap<iter_key_t<InputIterator>, iter_val_t<InputIterator>,
-                       less<iter_key_t<InputIterator>>,
-                       vector<iter_key_t<InputIterator>>,
-                       vector<iter_val_t<InputIterator>>>;
+      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
+                       less<@\placeholder{iter-key-type}@<InputIterator>>,
+                       vector<@\placeholder{iter-key-type}@<InputIterator>>,
+                       vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
   template<class Key, class T, class Compare = less<Key>>
     flat_multimap(initializer_list<pair<Key, T>>, Compare = Compare())

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10223,10 +10223,10 @@ namespace std {
 
   template <class Container>
     flat_map(Container)
-      -> flat_map<cont_key_t<Container>, cont_val_t<Container>,
-                  less<cont_key_t<Container>>,
-                  vector<cont_key_t<Container>>,
-                  vector<cont_val_t<Container>>>;
+      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-val-type}@<Container>,
+                  less<@\placeholder{cont-key-type}@<Container>>,
+                  vector<@\placeholder{cont-key-type}@<Container>>,
+                  vector<@\placeholder{cont-val-type}@<Container>>>;
 
   template <class KeyContainer, class MappedContainer>
     flat_map(KeyContainer, MappedContainer)
@@ -10237,10 +10237,10 @@ namespace std {
 
   template <class Container, class Alloc>
     flat_map(Container, Alloc)
-      -> flat_map<cont_key_t<Container>, cont_val_t<Container>,
-                  less<cont_key_t<Container>>,
-                  vector<cont_key_t<Container>>,
-                  vector<cont_val_t<Container>>>;
+      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-val-type}@<Container>,
+                  less<@\placeholder{cont-key-type}@<Container>>,
+                  vector<@\placeholder{cont-key-type}@<Container>>,
+                  vector<@\placeholder{cont-val-type}@<Container>>>;
 
   template <class KeyContainer, class MappedContainer, class Alloc>
     flat_map(KeyContainer, MappedContainer, Alloc)
@@ -10251,10 +10251,10 @@ namespace std {
 
   template <class Container>
     flat_map(sorted_unique_t, Container)
-      -> flat_map<cont_key_t<Container>, cont_val_t<Container>,
-                  less<cont_key_t<Container>>,
-                  vector<cont_key_t<Container>>,
-                  vector<cont_val_t<Container>>>;
+      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-val-type}@<Container>,
+                  less<@\placeholder{cont-key-type}@<Container>>,
+                  vector<@\placeholder{cont-key-type}@<Container>>,
+                  vector<@\placeholder{cont-val-type}@<Container>>>;
 
   template <class KeyContainer, class MappedContainer>
     flat_map(sorted_unique_t, KeyContainer, MappedContainer)
@@ -10265,10 +10265,10 @@ namespace std {
 
   template <class Container, class Alloc>
     flat_map(sorted_unique_t, Container, Alloc)
-      -> flat_map<cont_key_t<Container>, cont_val_t<Container>,
-                  less<cont_key_t<Container>>,
-                  vector<cont_key_t<Container>>,
-                  vector<cont_val_t<Container>>>;
+      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-val-type}@<Container>,
+                  less<@\placeholder{cont-key-type}@<Container>>,
+                  vector<@\placeholder{cont-key-type}@<Container>>,
+                  vector<@\placeholder{cont-val-type}@<Container>>>;
 
   template <class KeyContainer, class MappedContainer, class Alloc>
     flat_map(sorted_unique_t, KeyContainer, MappedContainer, Alloc)
@@ -11272,10 +11272,10 @@ namespace std {
 
   template <class Container>
     flat_multimap(Container)
-      -> flat_multimap<cont_key_t<Container>, cont_val_t<Container>,
-                       less<cont_key_t<Container>>,
-                       vector<cont_key_t<Container>>,
-                       vector<cont_val_t<Container>>>;
+      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-val-type}@<Container>,
+                       less<@\placeholder{cont-key-type}@<Container>>,
+                       vector<@\placeholder{cont-key-type}@<Container>>,
+                       vector<@\placeholder{cont-val-type}@<Container>>>;
 
   template <class KeyContainer, class MappedContainer>
     flat_multimap(KeyContainer, MappedContainer)
@@ -11286,10 +11286,10 @@ namespace std {
 
   template <class Container, class Alloc>
     flat_multimap(Container, Alloc)
-      -> flat_multimap<cont_key_t<Container>, cont_val_t<Container>,
-                       less<cont_key_t<Container>>,
-                       vector<cont_key_t<Container>>,
-                       vector<cont_val_t<Container>>>;
+      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-val-type}@<Container>,
+                       less<@\placeholder{cont-key-type}@<Container>>,
+                       vector<@\placeholder{cont-key-type}@<Container>>,
+                       vector<@\placeholder{cont-val-type}@<Container>>>;
 
   template <class KeyContainer, class MappedContainer, class Alloc>
     flat_multimap(KeyContainer, MappedContainer, Alloc)
@@ -11300,10 +11300,10 @@ namespace std {
 
   template <class Container>
     flat_multimap(sorted_equivalent_t, Container)
-      -> flat_multimap<cont_key_t<Container>, cont_val_t<Container>,
-                       less<cont_key_t<Container>>,
-                       vector<cont_key_t<Container>>,
-                       vector<cont_val_t<Container>>>;
+      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-val-type}@<Container>,
+                       less<@\placeholder{cont-key-type}@<Container>>,
+                       vector<@\placeholder{cont-key-type}@<Container>>,
+                       vector<@\placeholder{cont-val-type}@<Container>>>;
 
   template <class KeyContainer, class MappedContainer>
     flat_multimap(sorted_equivalent_t, KeyContainer, MappedContainer)
@@ -11314,10 +11314,10 @@ namespace std {
 
   template <class Container, class Alloc>
     flat_multimap(sorted_equivalent_t, Container, Alloc)
-      -> flat_multimap<cont_key_t<Container>, cont_val_t<Container>,
-                       less<cont_key_t<Container>>,
-                       vector<cont_key_t<Container>>,
-                       vector<cont_val_t<Container>>>;
+      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-val-type}@<Container>,
+                       less<@\placeholder{cont-key-type}@<Container>>,
+                       vector<@\placeholder{cont-key-type}@<Container>>,
+                       vector<@\placeholder{cont-val-type}@<Container>>>;
 
   template <class KeyContainer, class MappedContainer, class Alloc>
     flat_multimap(sorted_equivalent_t, KeyContainer, MappedContainer, Alloc)

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9997,7 +9997,7 @@ namespace std {
                const Alloc& a)
           : flat_map(key_container_type(std::move(key_cont), a),
                      mapped_container_type(std::move(mapped_cont), a))
-        {}
+        { }
       template <class Container>
         explicit flat_map(const Container& cont)
           : flat_map(cont.begin(), cont.end(), key_compare()) { }
@@ -10012,7 +10012,7 @@ namespace std {
                mapped_container_type&& mapped_cont, const Alloc& a)
           : flat_map(s, key_container_type(std::move(key_cont), a),
                      mapped_container_type(std::move(mapped_cont), a))
-        {}
+        { }
       template <class Container>
         flat_map(sorted_unique_t s, const Container& cont)
           : flat_map(s, cont.begin(), cont.end(), key_compare()) { }
@@ -10054,13 +10054,13 @@ namespace std {
           : compare{std::move(m.compare)}
           , c{key_container_type(std::move(m.c.keys), a),
               mapped_container_type(std::move(m.c.values), a)}
-        {}
+        { }
       template<class Alloc>
         flat_map(const flat_map& m, const Alloc& a)
           : compare{m.compare}
           , c{key_container_type(m.c.keys, a),
               mapped_container_type(m.c.values, a)}
-        {}
+        { }
 
       flat_map(initializer_list<pair<key_type, mapped_type>>&& il,
                const key_compare& comp = key_compare())
@@ -11054,7 +11054,7 @@ namespace std {
                     const Alloc& a)
           : flat_map(key_container_type(std::move(key_cont), a),
                      mapped_container_type(std::move(mapped_cont), a))
-        {}
+        { }
       template <class Container>
         explicit flat_multimap(const Container& cont)
           : flat_multimap(cont.begin(), cont.end(), key_compare()) { }
@@ -11069,7 +11069,7 @@ namespace std {
                     mapped_container_type&& mapped_cont, const Alloc& a)
           : flat_map(key_container_type(std::move(key_cont), a),
                      mapped_container_type(std::move(mapped_cont), a))
-        {}
+        { }
       template <class Container>
         flat_multimap(sorted_equivalent_t s, const Container& cont)
           : flat_multimap(s, cont.begin(), cont.end(), key_compare()) { }
@@ -11111,12 +11111,12 @@ namespace std {
           : compare{std::move(m.compare)}
           , c{key_container_type(std::move(m.c.keys), a),
               mapped_container_type(std::move(m.c.values), a)}
-        {}
+        { }
       template<class Alloc>
         flat_multimap(const flat_multimap& m, const Alloc& a)
           : compare{m.compare}
           , c{key_container_type(m.c.keys, a), mapped_container_type(m.c.values, a)}
-        {}
+        { }
 
       flat_multimap(initializer_list<pair<key_type, mapped_type>>&& il,
                     const key_compare& comp = key_compare())

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10216,10 +10216,10 @@ namespace std {
 
   template<class Container>
     using @\placeholder{cont-key-type}@ =
-      typename Container::value_type::first_type;   // \expos
+      remove_const_t<typename Container::value_type::first_type>;   // \expos
   template<class Container>
     using @\placeholder{cont-val-type}@ =
-      typename Container::value_type::second_type;  // \expos
+      typename Container::value_type::second_type;                  // \expos
 
   template <class Container>
     flat_map(Container)
@@ -11265,10 +11265,10 @@ namespace std {
 
   template<class Container>
     using @\placeholder{cont-key-type}@ =
-      typename Container::value_type::first_type;   // \expos
+      remove_const_t<typename Container::value_type::first_type>;   // \expos
   template<class Container>
     using @\placeholder{cont-val-type}@ =
-      typename Container::value_type::second_type;  // \expos
+      typename Container::value_type::second_type;                  // \expos
 
   template <class Container>
     flat_multimap(Container)

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9918,9 +9918,9 @@ A \tcode{flat_map} satisfies all of the requirements of a container, of a
 reversible container\iref{container.requirements}, and of an associative
 container\iref{associative.reqmts}, except for the requirements related to
 node handles\iref{container.node} and iterator
-invalidation\iref{container.adaptors.general}.  A \tcode{flat_map}
-does not meet the additional requirements of an allocator-aware container,
-\tref{containers.allocatoraware}.
+invalidation\iref{container.adaptors.general}.  A \tcode{flat_map} does not
+meet the additional requirements of an allocator-aware container, as described
+in \tref{containers.allocatoraware}.
 
 \pnum
 A \tcode{flat_map} also provides most operations described

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10018,7 +10018,7 @@ namespace std {
     };
 
     // \ref{flatmap.cons}, construct/copy/destroy
-    flat_map() : compare(key_compare()) { }
+    flat_map() : flat_map(key_compare()) { }
 
     flat_map(key_container_type key_cont, mapped_container_type mapped_cont);
     template <class Alloc>
@@ -11100,7 +11100,7 @@ namespace std {
     };
 
     // \ref{flatmultimap.cons}, construct/copy/destroy
-    flat_multimap() : compare(key_compare()) { }
+    flat_multimap() : flat_multimap(key_compare()) { }
 
     flat_multimap(key_container_type key_cont, mapped_container_type mapped_cont);
     template <class Alloc>

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10083,7 +10083,7 @@ namespace std {
       const_reverse_iterator  crbegin() const noexcept;
       const_reverse_iterator  crend() const noexcept;
 
-      // capacity
+      // \ref{flatmap.capacity}, capacity
       [[nodiscard]] bool empty() const noexcept;
       size_type size() const noexcept;
       size_type max_size() const noexcept;
@@ -10535,6 +10535,19 @@ for (; first != last; ++last) {
 \pnum
 \complexity
 Linear.
+\end{itemdescr}
+
+\rSec3[flatmap.capacity]{Capacity}
+
+\indexlibrary{\idxcode{max_size}!\idxcode{flatmap}}%
+\begin{itemdecl}
+size_type max_size() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return std::min<size_type>(c.keys.max_size(), c.values.max_size());}
 \end{itemdescr}
 
 \rSec3[flatmap.access]{Access}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -8911,7 +8911,7 @@ for the first form, or from the range
 The headers \tcode{<queue>}\changed{ and}{,} \tcode{<stack>}\added{,
 and \tcode{<flat_map>}} define the container adaptors
 \tcode{queue}, \tcode{priority_queue}\changed{ and}{,} \tcode{stack}\added{,
-\tcode{flat_map}, and \tcode{flat_multimap}}.
+\tcode{flat_map}}.
 
 \pnum
 For container adaptors, no \tcode{swap} function throws an exception unless
@@ -9913,23 +9913,13 @@ key value) and provides for fast retrieval of values of another type \tcode{T}
 based on the keys. The \tcode{flat_map} class supports random access
 iterators.
 
-TODO: [[nodiscard]] on empty().
-
-TODO: Front matter should say that it's an invariant that keys and values are
-the same size.  See first part of array overview. time.zone.overview too?
-Also, that the elements are sroted w.r.t. compare.
-
-TODO: Consistently say what happens to keys, values, compare in ctors.
-
-TODO: size() equivalent to keys.size()
-
-TODO: 3) unordered associative container table 72
-
-TODO: 4) say in fron matter that emplace will be used if the underlying containers have them.  Maybe put a paragraph before the modifiers section that says what happens; this an be in terms of a word of power ``INSERT_OR_EMPLACE''  NO! Explain what try_emplace does, though,
-
-TODO: 5) Taken care of by front matter invariants.
-
-TODO: 6) See try_emplace in map.modifiers
+%TODO: Front matter should say that it's an invariant that keys and values are
+%the same size.  See first part of array overview. time.zone.overview too?
+%Also, that the elements are sroted w.r.t. compare.
+%
+%TODO: Consistently say what happens to keys, values, compare in ctors.
+%
+%TODO: 5) Taken care of by front matter invariants.
 
 
 
@@ -9938,7 +9928,7 @@ A \tcode{flat_map} satisfies all of the requirements of a container, of a
 reversible container\iref{container.requirements}, and of an associative
 container\iref{associative.reqmts}, except for the requirements related to
 node handles\iref{container.node} and iterator
-invalidation\iref{containers.associative.requirements}.  A \tcode{flat_map}
+invalidation\iref{container.adaptors.general}.  A \tcode{flat_map}
 does not meet the additional requirements of an allocator-aware container,
 \tref{containers.allocatoraware}.
 
@@ -9956,9 +9946,8 @@ that are not described in one of those tables or for operations where
 there is additional semantic information.
 
 \pnum
-Any sequence container supporting random access iteration and operations
-\tcode{insert()} and \tcode{erase()} can be used to instantiate
-\tcode{flat_map}. In particular, \tcode{vector}\iref{vector} and
+Any sequence container supporting random access iteration can be used to
+instantiate \tcode{flat_map}. In particular, \tcode{vector}\iref{vector} and
 \tcode{deque}\iref{deque} can be used.
 
 \pnum
@@ -10540,6 +10529,17 @@ Linear.
 
 \indexlibrary{\idxcode{max_size}!\idxcode{flatmap}}%
 \begin{itemdecl}
+size_type size() const noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects
+Equivalent to: \tcode{return c.keys.size();}
+\end{itemdescr}
+
+\indexlibrary{\idxcode{max_size}!\idxcode{flatmap}}%
+\begin{itemdecl}
 size_type max_size() const noexcept;
 \end{itemdecl}
 
@@ -10604,8 +10604,7 @@ flat_map& operator=(initializer_list<pair<key_type, mapped_type>> il);
 \pnum
 \requires
 \tcode{key_type} shall be \tcode{CopyInsertable} into \tcode{key_container_type}, and
-\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
-from \tcode{args...}.
+\tcode{mapped_type} shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}.
 
 \pnum
 \effects Equivalent to:
@@ -10613,6 +10612,36 @@ from \tcode{args...}.
 clear();
 insert(il);
 \end{codeblock}
+\end{itemdescr}
+
+\indexlibrarymember{emplace}{flatmap}%
+\begin{itemdecl}
+template <class... Args> pair<iterator, bool> emplace(Args&&... args);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires
+\tcode{value_type} shall be \tcode{EmplaceConstructible} into \tcode{map} from \tcode{args}.
+
+\pnum
+\effects
+First, constructs a \tcode{pair<key_type, value_type>} object \tcode{t}
+constructed with \tcode{std::forward<Args>(args)...}.  If the map already
+contains an element whose key is equivalent to the key of \tcode{t}, there is
+no effect.  Otherwise, equivalent to:
+\begin{codeblock}
+auto key_it = lower_bound(c.keys.begin(), c.keys.end(), t.first);
+auto value_it = c.values.begin() + distance(c.keys.begin(), key_it);
+c.keys.emplace(key_it, std::move(t.first));
+c.values.emplace(value_it, std::move(t.second));
+\end{codeblock}
+
+\pnum
+\returns
+The \tcode{bool} component of the returned pair is \tcode{true} if and only if
+the insertion took place, and the iterator component of the pair points to the
+element with key equivalent to the key of \tcode{t}.
 \end{itemdescr}
 
 \indexlibrarymember{insert}{flatmap}%
@@ -10647,24 +10676,25 @@ template<class... Args>
 \pnum
 \requires
 \tcode{key_type} shall be \tcode{CopyInsertable} into \tcode{key_container_type}, and
-\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
+\tcode{mapped_type} shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
 from \tcode{args...}.
 
 \pnum
 \effects
-If the map already contains an element
-whose key is equivalent to \tcode{k},
-there is no effect.
-Otherwise equivalent to \tcode{emplace(k, std::forward<Args>(args)...)} or
-\tcode{emplace(hint, k, std::forward<Args>(args)...)} respectively.
+If the map already contains an element whose key is equivalent to \tcode{k},
+there is no effect.  Otherwise equivalent to:
+\begin{codeblock}
+auto key_it = lower_bound(c.keys.begin(), c.keys.end(), k);
+auto value_it = c.values.begin() + distance(c.keys.begin(), key_it);
+c.keys.insert(key_it, k);
+c.values.emplace(value_it, std::forward<Args>(args)...);
+\end{codeblock}
 
 \pnum
 \returns
-In the first overload,
-the \tcode{bool} component of the returned pair is \tcode{true}
-if and only if the insertion took place.
-The returned iterator points to the map element
-whose key is equivalent to \tcode{k}.
+In the first overload, the \tcode{bool} component of the returned pair
+is \tcode{true} if and only if the insertion took place.  The returned
+iterator points to the map element whose key is equivalent to \tcode{k}.
 
 \pnum
 \complexity
@@ -10689,11 +10719,14 @@ from \tcode{args...}.
 
 \pnum
 \effects
-If the map already contains an element
-whose key is equivalent to \tcode{k},
-there is no effect.
-Otherwise equivalent to \tcode{emplace(std::move(k), std::forward<Args>(args)...)} or
-\tcode{emplace(hint, std::move(k), std::forward<Args>(args)...)} respectively.
+If the map already contains an element whose key is equivalent to \tcode{k},
+there is no effect.  Otherwise equivalent to:
+\begin{codeblock}
+auto key_it = lower_bound(c.keys.begin(), c.keys.end(), k);
+auto value_it = c.values.begin() + distance(c.keys.begin(), key_it);
+c.keys.emplace(key_it, std::move(k));
+c.values.emplace(value_it, std::forward<Args>(args)...);
+\end{codeblock}
 
 \pnum
 \returns
@@ -10975,9 +11008,9 @@ A \tcode{flat_multimap} satisfies all of the requirements of a container, of a
 reversible container\iref{container.requirements}, and of an associative
 container\iref{associative.reqmts}, except for the requirements related to
 node handles\iref{container.node} and iterator
-invalidation\iref{containers.associative.requirements}.
-A \tcode{flat_multimap} does not meet the additional requirements of an
-allocator-aware container, as described in
+invalidation\iref{container.adaptors.general}.  A \tcode{flat_multimap}
+does not meet the additional requirements of an allocator-aware container, as
+described in
 \tref{containers.allocatoraware}.
 
 \pnum
@@ -10994,10 +11027,9 @@ that are not described in one of those tables or for operations where
 there is additional semantic information.
 
 \pnum
-Any sequence container supporting random access iteration and operations
-\tcode{insert()} and \tcode{erase()} can be used to instantiate
-\tcode{flat_multimap}. In particular, \tcode{vector}\iref{vector} and
-\tcode{deque}\iref{deque} can be used.
+Any sequence container supporting random access iteration can be used to
+instantiate \tcode{flat_multimap}. In particular, \tcode{vector}\iref{vector}
+and \tcode{deque}\iref{deque} can be used.
 
 \pnum
 The template parameters \tcode{Key} and \tcode{T} of \tcode{flat_multimap}
@@ -11557,6 +11589,36 @@ insert(il);
 \end{codeblock}
 \end{itemdescr}
 
+\indexlibrarymember{emplace}{flatmultimap}%
+\begin{itemdecl}
+template <class... Args> pair<iterator, bool> emplace(Args&&... args);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires
+\tcode{value_type} shall be \tcode{EmplaceConstructible} into \tcode{map} from \tcode{args}.
+
+\pnum
+\effects
+First, constructs a \tcode{pair<key_type, value_type>} object \tcode{t}
+constructed with \tcode{std::forward<Args>(args)...}.  If the map already
+contains an element whose key is equivalent to the key of \tcode{t}, there is
+no effect.  Otherwise, equivalent to:
+\begin{codeblock}
+auto key_it = upper_bound(c.keys.begin(), c.keys.end(), t.first);
+auto value_it = c.values.begin() + distance(c.keys.begin(), key_it);
+c.keys.emplace(key_it, std::move(t.first));
+c.values.emplace(value_it, std::move(t.second));
+\end{codeblock}
+
+\pnum
+\returns
+The \tcode{bool} component of the returned pair is \tcode{true} if and only if
+the insertion took place, and the iterator component of the pair points to the
+element with key equivalent to the key of \tcode{t}.
+\end{itemdescr}
+
 \indexlibrarymember{insert}{flatmultimap}%
 \begin{itemdecl}
 template<class P> iterator insert(P&& x);
@@ -11599,6 +11661,84 @@ void insert(sorted_unique_t, initializer_list<pair<key_type, mapped_type>> il);
 
 \begin{itemdescr}
 \pnum Effects: Equivalent to \tcode{insert(sorted_unique_t{}, il.begin(), il.end())}.
+\end{itemdescr}
+
+\indexlibrarymember{try_emplace}{flatmultimap}%
+\begin{itemdecl}
+template<class... Args>
+  pair<iterator, bool> try_emplace(const key_type& k, Args&&... args);
+template<class... Args>
+  iterator try_emplace(const_iterator hint, const key_type& k, Args&&... args);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires
+\tcode{key_type} shall be \tcode{CopyInsertable} into \tcode{key_container_type}, and
+\tcode{mapped_type} shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
+from \tcode{args...}.
+
+\pnum
+\effects
+If the map already contains an element whose key is equivalent to \tcode{k},
+there is no effect.  Otherwise equivalent to:
+\begin{codeblock}
+auto key_it = upper_bound(c.keys.begin(), c.keys.end(), k);
+auto value_it = c.values.begin() + distance(c.keys.begin(), key_it);
+c.keys.insert(key_it, k);
+c.values.emplace(value_it, std::forward<Args>(args)...);
+\end{codeblock}
+
+\pnum
+\returns
+In the first overload, the \tcode{bool} component of the returned pair
+is \tcode{true} if and only if the insertion took place.  The returned
+iterator points to the map element whose key is equivalent to \tcode{k}.
+
+\pnum
+\complexity
+The same as \tcode{emplace} and \tcode{emplace_hint},
+respectively.
+\end{itemdescr}
+
+\indexlibrarymember{try_emplace}{flatmultimap}%
+\begin{itemdecl}
+template<class... Args>
+  pair<iterator, bool> try_emplace(key_type&& k, Args&&... args);
+template<class... Args>
+  iterator try_emplace(const_iterator hint, key_type&& k, Args&&... args);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\requires
+\tcode{key_type} shall be \tcode{MoveInsertable} into \tcode{key_container_type}, and
+\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
+from \tcode{args...}.
+
+\pnum
+\effects
+If the map already contains an element whose key is equivalent to \tcode{k},
+there is no effect.  Otherwise equivalent to:
+\begin{codeblock}
+auto key_it = upper_bound(c.keys.begin(), c.keys.end(), k);
+auto value_it = c.values.begin() + distance(c.keys.begin(), key_it);
+c.keys.emplace(key_it, std::move(k));
+c.values.emplace(value_it, std::forward<Args>(args)...);
+\end{codeblock}
+
+\pnum
+\returns
+In the first overload,
+the \tcode{bool} component of the returned pair is \tcode{true}
+if and only if the insertion took place.
+The returned iterator points to the map element
+whose key is equivalent to \tcode{k}.
+
+\pnum
+\complexity
+The same as \tcode{emplace} and \tcode{emplace_hint},
+respectively.
 \end{itemdescr}
 
 \indexlibrarymember{flatmultimap}{swap}%

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -12641,6 +12641,129 @@ class flat_multiset {
 }
 \end{codeblock}
 
+\rSec3[flatmultiset.cons]{Constructors}
+
+\indexlibrary{\idxcode{flatmultiset}!constructor}%
+\begin{itemdecl}
+flat_multiset(container_type cont);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Initializes \tcode{c} with \tcode{std::move(cont)}, value-initializes
+\tcode{compare}, and sorts the range \range{begin()}{end()} with
+\tcode{compare}.
+
+\pnum
+\complexity
+Linear in $N$ if \tcode{cont} is sorted as if with \tcode{compare} and
+otherwise $N \log N$, where $N$ is \tcode{cont.size()}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{flatmultiset}!constructor}%
+\begin{itemdecl}
+template <class InputIterator>
+  flat_multiset(InputIterator first, InputIterator last, const key_compare& comp);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Initializes \tcode{compare} with \tcode{comp}, initializes \tcode{c}
+with \range{first}{last}, and sorts the range \range{begin()}{end()}
+with \tcode{compare}.
+
+\pnum
+\complexity
+Linear in $N$ if \range{first}{last} is already sorted as if with \tcode{compare} and
+otherwise $N \log N$, where $N$ is \tcode{distance(first, last)}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{flatmultiset}!constructor}%
+\begin{itemdecl}
+template <class InputIterator>
+  flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
+                const key_compare& comp = key_compare());
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Initializes \tcode{compare} with \tcode{comp}, and initializes
+\tcode{c} with \range{first}{last}.
+
+\pnum
+\complexity
+Linear.
+\end{itemdescr}
+
+\rSec3[flatmultiset.cons.alloc]{Constructors with allocators}
+
+\indexlibrary{\idxcode{flatmultiset}!constructor}%
+\begin{itemdecl}
+template <class Alloc>
+  flat_multiset(const key_compare& comp, const Alloc& a);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Initializes \tcode{compare} with \tcode{comp}, and performs
+uses-allocator construction\iref{allocator.uses.construction} of
+\tcode{c} with \tcode{a}.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{flatmultiset}!constructor}%
+\begin{itemdecl}
+template <class InputIterator, class Alloc>
+  flat_multiset(InputIterator first, InputIterator last,
+                const key_compare& comp, const Alloc& a);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Initializes \tcode{compare} with \tcode{comp}, and performs
+uses-allocator construction\iref{allocator.uses.construction} of \tcode{c}
+with \tcode{a}; adds elements to \tcode{c} as if by:
+\begin{codeblock}
+for (; first != last; ++first) {
+  c.insert(c.end(), *first);
+}
+\end{codeblock}
+and finally sorts the range \range{begin()}{end()} with \tcode{compare}.
+
+\pnum
+\complexity
+Linear in $N$ if \range{first}{last} is sorted as if with \tcode{compare} and
+otherwise $N \log N$, where $N$ is \tcode{distance(first, last)}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{flatmultiset}!constructor}%
+\begin{itemdecl}
+template <class InputIterator, class Alloc>
+  flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
+                const key_compare& comp, const Alloc& a);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Initializes \tcode{compare} with \tcode{comp}, and performs
+uses-allocator construction\iref{allocator.uses.construction} of \tcode{c}
+with \tcode{a}; adds elements to \tcode{c} as if by:
+\begin{codeblock}
+for (; first != last; ++first) {
+  c.insert(c.end(), *first);
+}
+\end{codeblock}
+
+\pnum
+\complexity
+Linear.
+\end{itemdescr}
+
+\rSec3[flatmultiset.modifiers]{Modifiers}
+
 TODO
 \end{addedblock}
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -1560,8 +1560,9 @@ For \tcode{set} and \tcode{multiset} the value type is the same as the key type.
 For \tcode{map} and \tcode{multimap} it is equal to \tcode{pair<const Key, T>}.
 
 \pnum
-\tcode{iterator}
-of an associative container \changed{is of}{meets} the bidirectional iterator \changed{category}{requirements}.
+\changed{\tcode{iterator}
+of an associative container is of the bidirectional iterator category.}
+{An associative container's \tcode{iterator} meets the bidirectional iterator requirements.}
 For associative containers where the value type is the same as the key type, both
 \tcode{iterator}
 and
@@ -8907,48 +8908,16 @@ for the first form, or from the range
 \rSec2[container.adaptors.general]{In general}
 
 \pnum
-The headers \tcode{<queue>}\changed{ and}{,} \tcode{<stack>}\changed{ define the container adaptors
-\tcode{queue},}{, and \tcode{<flat_map>} define
-the container adaptors} \tcode{queue}, \tcode{priority_queue}\changed{,}{ and} \tcode{stack}\added{,
+The headers \tcode{<queue>}\changed{ and}{,} \tcode{<stack>}\added{,
+and \tcode{<flat_map>}} define the container adaptors
+\tcode{queue}, \tcode{priority_queue}\changed{ and}{,} \tcode{stack}\added{,
 \tcode{flat_map}, and \tcode{flat_multimap}}.
 
-\pnum
-\changed{The}{Each} container adaptor\changed{s each take a}{ except \tcode{flat_map} and} \changed{\tcode{Container} template parameter, and each constructor}{\tcode{flat_multimap}} takes
-a \tcode{Container} \changed{reference argument. This}{template parameter, and each} \changed{container is copied into the \tcode{Container} member
-of each adaptor. If the container takes an allocator, then a compatible allocator may be passed in
-to the adaptor's constructor. Otherwise, normal copy or move construction is used for the container
-argument.
-The first template parameter \tcode{T} of the container adaptors
-shall denote the same type as \tcode{Container::value_type}}{constructor takes
-a \tcode{Container} reference argument. This container is copied into
-the \tcode{Container} member of each of these adaptors. If the container takes
-an allocator, then a compatible allocator may be passed in to the adaptor's
-constructor. Otherwise, normal copy or move construction is used for the
-container argument.  The first template parameter \tcode{T} of each of these
-container adaptors shall denote the same type
-as \tcode{Container::value_type}}.
-
-\pnum
-\changed{For container adaptors, no \tcode{swap} function throws an exception unless that
-exception is thrown by the swap of the adaptor's \tcode{Container} or}{The container adaptors \tcode{flat_map}, and \tcode{flat_multimap} each take
-\tcode{KeyContainer} and \tcode{MappedContainer} template parameters.  Many constructors take
-\tcode{KeyContainer} and \tcode{MappedContainer} reference arguments. These containers are copied into
-the \tcode{KeyContainer} and \tcode{MappedContainer} members of each of these
-adaptors. If one or more of the containers takes an allocator, then a
-compatible allocator may be passed in to the adaptor's constructor. Otherwise,
-normal copy or move construction is used for the container argument.  The
-first template parameters \tcode{Key} and \tcode{T} of each of these
-container adaptors shall denote the same type
-as \tcode{KeyContainer::value_type} and \tcode{MappedContainer::value_type},
-respectively}\tcode{Compare} object (if any).
-
-\begin{addedblock}
 \pnum
 For container adaptors, no \tcode{swap} function throws an exception unless
 that exception is thrown by the swap of the
 adaptor's \tcode{Container}, \tcode{KeyContainer}, \tcode{MappedContainer}, or
 \tcode{Compare} object (if any).
-\end{addedblock}
 
 \begin{addedblock}
 \pnum
@@ -9124,6 +9093,12 @@ namespace std {
 \end{addedblock}
 
 \rSec2[queue]{Class template \tcode{queue}}
+
+\begin{codeblock}
+\pnum
+The first template parameter \tcode{T} of \tcode{queue} shall denote the same
+type as \tcode{Container::value_type}.
+\end{addedblock}
 
 \rSec3[queue.defn]{Definition}
 
@@ -9389,6 +9364,12 @@ Instantiating
 also involves supplying a function or function object for making
 priority comparisons; the library assumes that the function or function
 object defines a strict weak ordering\iref{alg.sorting}.
+
+\begin{codeblock}
+\pnum
+The first template parameter \tcode{T} of \tcode{priority_queue} shall denote
+the same type as \tcode{Container::value_type}.
+\end{addedblock}
 
 \begin{codeblock}
 namespace std {
@@ -9689,6 +9670,12 @@ and
 \tcode{deque}\iref{deque}
 can be used.
 
+\begin{codeblock}
+\pnum
+The first template parameter \tcode{T} of \tcode{stack} shall denote the same
+type as \tcode{Container::value_type}.
+\end{addedblock}
+
 \rSec3[stack.defn]{Definition}
 
 \begin{codeblock}
@@ -9952,6 +9939,11 @@ Any sequence container supporting random access iteration and operations
 \tcode{insert()} and \tcode{erase()} can be used to instantiate
 \tcode{flat_map}. In particular, \tcode{vector}\iref{vector} and
 \tcode{deque}\iref{deque} can be used.
+
+\pnum
+The template parameters \tcode{Key} and \tcode{T} of \tcode{flat_map} shall
+denote the same type as \tcode{KeyContainer::value_type}
+and \tcode{MappedContainer::value_type}, respectively.
 
 \rSec3[flatmap.defn]{Definition}
 
@@ -10989,6 +10981,11 @@ Any sequence container supporting random access iteration and operations
 \tcode{insert()} and \tcode{erase()} can be used to instantiate
 \tcode{flat_multimap}. In particular, \tcode{vector}\iref{vector} and
 \tcode{deque}\iref{deque} can be used.
+
+\pnum
+The template parameters \tcode{Key} and \tcode{T} of \tcode{flat_multimap}
+shall denote the same type as \tcode{KeyContainer::value_type}
+and \tcode{MappedContainer::value_type}, respectively.
 
 \rSec3[flatmultimap.defn]{Definition}
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10162,6 +10162,9 @@ namespace std {
       key_compare key_comp() const;
       value_compare value_comp() const;
 
+      const key_container_type& keys() const      { return c.keys; }
+      const mapped_container_type& values() const { return c.values; }
+
       // map operations
       bool contains(const key_type& x) const;
       template <class K> bool contains(const K& x) const;
@@ -11166,6 +11169,9 @@ namespace std {
       // observers
       key_compare key_comp() const;
       value_compare value_comp() const;
+
+      const key_container_type& keys() const      { return c.keys; }
+      const mapped_container_type& values() const { return c.values; }
 
       // map operations
       bool contains(const key_type& x) const;

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10589,7 +10589,7 @@ mapped_type& operator[](key_type&& x);
 \begin{itemdescr}
 \pnum
 \effects
-Equivalent to: \tcode{return try_emplace(move(x)).first->second;}
+Equivalent to: \tcode{return try_emplace(std::move(x)).first->second;}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{at}!\idxcode{flatmap}}%

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10018,7 +10018,7 @@ namespace std {
       };
 
       // \ref{flatmap.cons}, construct/copy/destroy
-      flat_map();
+      flat_map() : compare(key_compare()) { }
 
       flat_map(key_container_type key_cont, mapped_container_type mapped_cont);
       template <class Alloc>
@@ -10049,7 +10049,8 @@ namespace std {
         flat_map(sorted_unique_t s, const Container& cont, const Alloc& a)
           : flat_map(s, cont.begin(), cont.end(), key_compare(), a) { }
 
-      explicit flat_map(const key_compare& comp);
+      explicit flat_map(const key_compare& comp)
+        : c(containers()), compare(comp) { }
       template <class Alloc>
         flat_map(const key_compare& comp, const Alloc& a);
       template <class Alloc>
@@ -10374,10 +10375,10 @@ flat_map(key_container_type key_cont, mapped_container_type mapped_cont);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{c.keys} with
-\tcode{std::move(key_cont)} and \tcode{c.values} with
-\tcode{std::move(mapped_cont)}; value-initializes \tcode{compare}; and sorts the range
-\range{begin()}{end()} with \tcode{compare}.
+\effects Initializes \tcode{c.keys} with \tcode{std::move(key_cont)} and
+\tcode{c.values} with \tcode{std::move(mapped_cont)}; value-initializes
+\tcode{compare}; and sorts the range \range{begin()}{end()} with
+\tcode{compare}.
 
 \pnum
 \complexity
@@ -10402,17 +10403,29 @@ flat_map(sorted_unique_t, key_container_type key_cont, mapped_container_type map
 Constant.
 \end{itemdescr}
 
+\indexlibrary{\idxcode{flatmap}!constructor}%
 \begin{itemdecl}
-explicit flat_map(const key_compare& comp);
+template <class InputIterator>
+  flat_map(InputIterator first, InputIterator last, const key_compare& comp);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{compare} with \tcode{comp}; value-initializes \tcode{c}.
+\effects Initializes \tcode{compare} with \tcode{comp}, adds elements to
+\tcode{c} as if by:
+\begin{codeblock}
+for (; first != last; ++first) {
+  c.keys.insert(c.keys.end(), first->first); 
+  c.values.insert(c.values.end(), first->second); 
+}
+\end{codeblock}
+and finally sorts the range \range{begin()}{end()} with \tcode{compare}.
 
 \pnum
 \complexity
-Constant.
+Linear in $N$ if the container arguments are already sorted as if with
+\tcode{compare} and otherwise $N \log N$, where $N$ is
+\tcode{key_cont.size()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{flatmap}!constructor}%
@@ -10424,8 +10437,8 @@ template <class InputIterator>
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{compare} with
-\tcode{comp}, and adds elements to \tcode{c.keys} and \tcode{c.values} as if by:
+\effects Initializes \tcode{compare} with \tcode{comp}, and adds elements to
+\tcode{c.keys} and \tcode{c.values} as if by:
 \begin{codeblock}
 for (; first != last; ++first) {
   c.keys.insert(c.keys.end(), first->first);
@@ -10451,6 +10464,10 @@ template <class Alloc>
 \effects Initializes \tcode{compare} with \tcode{comp}, and performs
 uses-allocator construction\iref{allocator.uses.construction} of both
 \tcode{c.keys} and \tcode{c.values} with \tcode{a}.
+
+\pnum
+\complexity
+Constant.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{flatmap}!constructor}%
@@ -10467,12 +10484,18 @@ uses-allocator construction\iref{allocator.uses.construction} of both
 \tcode{c.keys} and \tcode{c.values} with \tcode{a}; adds elements to
 \tcode{c.keys} and \tcode{c.values} as if by:
 \begin{codeblock}
-for (; first != last; ++last) {
+for (; first != last; ++first) {
   c.keys.insert(c.keys.end(), first->first);
   c.values.insert(c.values.end(), first->second);
 }
 \end{codeblock}
 and finally sorts the range \range{begin()}{end()} with \tcode{compare}.
+
+\pnum
+\complexity
+Linear in $N$ if the container arguments are already sorted as if with
+\tcode{compare} and otherwise $N \log N$, where $N$ is
+\tcode{distance(first, last)}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{flatmap}!constructor}%
@@ -10489,7 +10512,7 @@ uses-allocator construction\iref{allocator.uses.construction} of both
 \tcode{c.keys} and \tcode{c.values} with \tcode{a}; adds elements to
 \tcode{c.keys} and \tcode{c.values} as if by:
 \begin{codeblock}
-for (; first != last; ++last) {
+for (; first != last; ++first) {
   c.keys.insert(c.keys.end(), first->first);
   c.values.insert(c.values.end(), first->second);
 }
@@ -11077,7 +11100,7 @@ namespace std {
       };
 
       // \ref{flatmultimap.cons}, construct/copy/destroy
-      flat_multimap();
+      flat_multimap() : compare(key_compare()) { }
 
       flat_multimap(key_container_type key_cont, mapped_container_type mapped_cont);
       template <class Alloc>
@@ -11108,7 +11131,8 @@ namespace std {
         flat_multimap(sorted_equivalent_t s, const Container& cont, const Alloc& a)
           : flat_multimap(s, cont.begin(), cont.end(), key_compare(), a) { }
 
-      explicit flat_multimap(const key_compare& comp);
+      explicit flat_multimap(const key_compare& comp)
+        : c(containers()), compare(comp) { }
       template <class Alloc>
         flat_multimap(const key_compare& comp, const Alloc& a);
       template <class Alloc>
@@ -11409,10 +11433,10 @@ flat_multimap(key_container_type key_cont, mapped_container_type mapped_cont);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{c.keys} with
-\tcode{std::move(key_cont)} and \tcode{c.values} with
-\tcode{std::move(mapped_cont)}; value-initializes \tcode{compare}; and sorts the range
-\range{begin()}{end()} with \tcode{compare}.
+\effects Initializes \tcode{c.keys} with \tcode{std::move(key_cont)} and
+\tcode{c.values} with \tcode{std::move(mapped_cont)}; value-initializes
+\tcode{compare}; and sorts the range \range{begin()}{end()} with
+\tcode{compare}.
 
 \pnum
 \complexity
@@ -11435,6 +11459,31 @@ flat_multimap(sorted_equivalent_t, key_container_type key_cont, mapped_container
 \pnum
 \complexity
 Constant.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{flatmultimap}!constructor}%
+\begin{itemdecl}
+template <class InputIterator>
+  flat_multimap(InputIterator first, InputIterator last, const key_compare& comp);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Initializes \tcode{compare} with \tcode{comp}, adds elements to
+\tcode{c} as if by:
+\begin{codeblock}
+for (; first != last; ++first) {
+  c.keys.insert(c.keys.end(), first->first); 
+  c.values.insert(c.values.end(), first->second); 
+}
+\end{codeblock}
+and finally sorts the range \range{begin()}{end()} with \tcode{compare}.
+
+\pnum
+\complexity
+Linear in $N$ if the container arguments are already sorted as if with
+\tcode{compare} and otherwise $N \log N$, where $N$ is
+\tcode{key_cont.size()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{flatmultimap}!constructor}%
@@ -11489,12 +11538,18 @@ uses-allocator construction\iref{allocator.uses.construction} of both
 \tcode{c.keys} and \tcode{c.values} with \tcode{a}; adds elements to
 \tcode{c.keys} and \tcode{c.values} as if by:
 \begin{codeblock}
-for (; first != last; ++last) {
+for (; first != last; ++first) {
   c.keys.insert(c.keys.end(), first->first);
   c.values.insert(c.values.end(), first->second);
 }
 \end{codeblock}
 and finally sorts the range \range{begin()}{end()} with \tcode{compare}.
+
+\pnum
+\complexity
+Linear in $N$ if the container arguments are already sorted as if with
+\tcode{compare} and otherwise $N \log N$, where $N$ is
+\tcode{key_cont.size()}.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{flatmultimap}!constructor}%
@@ -11511,7 +11566,7 @@ uses-allocator construction\iref{allocator.uses.construction} of both
 \tcode{c.keys} and \tcode{c.values} with \tcode{a}; adds elements to
 \tcode{c.keys} and \tcode{c.values} as if by:
 \begin{codeblock}
-for (; first != last; ++last) {
+for (; first != last; ++first) {
   c.keys.insert(c.keys.end(), first->first);
   c.values.insert(c.values.end(), first->second);
 }

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9916,12 +9916,6 @@ iterators.
 %TODO: Front matter should say that it's an invariant that keys and values are
 %the same size.  See first part of array overview. time.zone.overview too?
 %Also, that the elements are sroted w.r.t. compare.
-%
-%TODO: Consistently say what happens to keys, values, compare in ctors.
-%
-%TODO: 5) Taken care of by front matter invariants.
-
-
 
 \pnum
 A \tcode{flat_map} satisfies all of the requirements of a container, of a
@@ -10385,7 +10379,7 @@ flat_map(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
 \pnum
 \effects Initializes \tcode{c.keys} with
 \tcode{std::move(key_cont)} and \tcode{c.values} with
-\tcode{std::move(mapped_cont)}; sorts the range
+\tcode{std::move(mapped_cont)}; value-initializes \tcode{compare}; and sorts the range
 \range{begin()}{end()} with \tcode{compare}.
 
 \pnum
@@ -10404,7 +10398,7 @@ flat_map(sorted_unique_t, key_container_type&& key_cont, mapped_container_type&&
 \pnum
 \effects Initializes \tcode{c.keys} with
 \tcode{std::move(key_cont)} and \tcode{c.values} with
-\tcode{std::move(mapped_cont)}.
+\tcode{std::move(mapped_cont)}; value-initializes \tcode{compare}.
 
 \pnum
 \complexity
@@ -10417,7 +10411,7 @@ explicit flat_map(const key_compare& comp);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{compare} with \tcode{comp}.
+\effects Initializes \tcode{compare} with \tcode{comp}; value-initializes \tcode{c}.
 
 \pnum
 \complexity
@@ -11440,7 +11434,7 @@ flat_multimap(key_container_type&& key_cont, mapped_container_type&& mapped_cont
 \pnum
 \effects Initializes \tcode{c.keys} with
 \tcode{std::move(key_cont)} and \tcode{c.values} with
-\tcode{std::move(mapped_cont)}; sorts the range
+\tcode{std::move(mapped_cont)}; value-initializes \tcode{compare}; and sorts the range
 \range{begin()}{end()} with \tcode{compare}.
 
 \pnum
@@ -11459,7 +11453,7 @@ flat_multimap(sorted_equivalent_t, key_container_type&& key_cont, mapped_contain
 \pnum
 \effects Initializes \tcode{c.keys} with
 \tcode{std::move(key_cont)} and \tcode{c.values} with
-\tcode{std::move(mapped_cont)}.
+\tcode{std::move(mapped_cont)}; value-initializes \tcode{compare}.
 
 \pnum
 \complexity

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10877,13 +10877,7 @@ containers extract() &&;
 \end{itemdecl}
 
 \begin{itemdescr}
-\effects Equivalent to:
-\begin{codeblock}
-containers temp;
-temp.keys.swap(c.keys);
-temp.values.swap(c.values);
-return temp;
-\end{codeblock}
+\effects Equivalent to \tcode{return std::move(c);}
 \end{itemdescr}
 
 \indexlibrarymember{flatmap}{replace}%
@@ -11698,13 +11692,7 @@ containers extract() &&;
 \end{itemdecl}
 
 \begin{itemdescr}
-\effects Equivalent to:
-\begin{codeblock}
-containers temp;
-temp.keys.swap(c.keys);
-temp.values.swap(c.values);
-return temp;
-\end{codeblock}
+\effects Equivalent to \tcode{return std::move(c);}
 \end{itemdescr}
 
 \indexlibrarymember{flatmultimap}{replace}%
@@ -12368,12 +12356,7 @@ container_type extract() &&;
 \end{itemdecl}
 
 \begin{itemdescr}
-\effects Equivalent to:
-\begin{codeblock}
-container_type temp;
-temp.swap(c);
-return temp;
-\end{codeblock}
+\effects Equivalent to \tcode{return std::move(c);}
 \end{itemdescr}
 
 \indexlibrarymember{flatset}{replace}%
@@ -13032,12 +13015,7 @@ container_type extract() &&;
 \end{itemdecl}
 
 \begin{itemdescr}
-\effects Equivalent to:
-\begin{codeblock}
-container_type temp;
-temp.swap(c);
-return temp;
-\end{codeblock}
+\effects Equivalent to \tcode{return std::move(c);}
 \end{itemdescr}
 
 \indexlibrarymember{flatmultiset}{replace}%

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -11838,7 +11838,7 @@ A \tcode{flat_set} also provides most operations described
 in~\ref{associative.reqmts} for unique keys.  This means that a
 \tcode{flat_set} supports the \tcode{a_uniq} operations
 in~\ref{associative.reqmts} but not the \tcode{a_eq} operations.  For a
-\tcode{flat_set<Key,T>} both the \tcode{key_type} and \tcode{key_type} are
+\tcode{flat_set<Key>} both the \tcode{key_type} and \tcode{mapped_type} are
 \tcode{Key}.
 
 \pnum
@@ -11862,11 +11862,11 @@ participate in overload resolution only if both \tcode{std::begin(cont)} and
 
 \pnum
 The effect of calling a constructor that takes a \tcode{sorted_unique_t}
-argument with a range that is not sorted with respect to \tcode{compare} is
-undefined.
+argument with a range that is not sorted with respect to \tcode{compare}, or
+that contains equal elements, is undefined.
 
 \pnum
-Constructors that take a \tcode{Alloc} argument shall participate in overload
+Constructors that take an \tcode{Alloc} argument shall participate in overload
 resolution only if \tcode{uses_allocator_v<container_type, Alloc>} is
 \tcode{true}.
 
@@ -12173,8 +12173,8 @@ flat_set(container_type cont);
 
 \begin{itemdescr}
 \pnum
-\effects Initializes \tcode{c} with \tcode{std::move(cont)}; value-initializes
-\tcode{compare}; and sorts the range \range{begin()}{end()} with
+\effects Initializes \tcode{c} with \tcode{std::move(cont)}, value-initializes
+\tcode{compare}, and sorts the range \range{begin()}{end()} with
 \tcode{compare}.
 
 \pnum
@@ -12192,12 +12192,12 @@ template <class InputIterator>
 \begin{itemdescr}
 \pnum
 \effects Initializes \tcode{compare} with \tcode{comp}, initializes \tcode{c}
-with \range{first}{last}, and finally sorts the range \range{begin()}{end()}
+with \range{first}{last}, and sorts the range \range{begin()}{end()}
 with \tcode{compare}.
 
 \pnum
 \complexity
-Linear in $N$ if \tcode{cont} is already sorted as if with \tcode{compare} and
+Linear in $N$ if \range{first}{last} is already sorted as if with \tcode{compare} and
 otherwise $N \log N$, where $N$ is \tcode{distance(first, last)}.
 \end{itemdescr}
 
@@ -12211,7 +12211,7 @@ template <class InputIterator>
 \begin{itemdescr}
 \pnum
 \effects Initializes \tcode{compare} with \tcode{comp}, and initializes
-\tcode{c} from \range{first}{last}.
+\tcode{c} with \range{first}{last}.
 
 \pnum
 \complexity
@@ -12258,7 +12258,7 @@ and finally sorts the range \range{begin()}{end()} with \tcode{compare}.
 
 \pnum
 \complexity
-Linear in $N$ if \tcode{cont} is sorted as if with \tcode{compare} and
+Linear in $N$ if \range{first}{last} is sorted as if with \tcode{compare} and
 otherwise $N \log N$, where $N$ is \tcode{distance(first, last)}.
 \end{itemdescr}
 
@@ -12286,6 +12286,71 @@ Linear.
 \end{itemdescr}
 
 \rSec3[flatset.modifiers]{Modifiers}
+
+TODO
+
+\rSec2[flatmultiset]{Class template \tcode{flat_multiset}}
+
+\pnum
+\indexlibrary{\idxcode{flatmultiset}}%
+A \tcode{flat_multiset} is a container adaptor that provides an associative
+container interface that supports equivalent keys (possibly containing
+multiple copies of the same key value) and provides for fast retrieval of the
+keys themselves. The \tcode{flat_multiset} class supports random access
+iterators.
+
+\pnum
+A \tcode{flat_multiset} satisfies all of the requirements of a container, of a
+reversible container\iref{container.requirements}, and of an associative
+container\iref{associative.reqmts}, except for the requirements related to
+node handles\iref{container.node} and iterator
+invalidation\iref{container.adaptors.general}.  A \tcode{flat_multiset} does
+not meet the additional requirements of an allocator-aware container, as
+described in \tref{containers.allocatoraware}.
+
+\pnum
+A \tcode{flat_multiset} also provides most operations described
+in~\ref{associative.reqmts} for equal keys.  This means that a
+\tcode{flat_multiset} supports the \tcode{a_eq} operations
+in~\ref{associative.reqmts} but not the \tcode{a_uniq} operations.  For a
+\tcode{flat_multiset<Key>} both the \tcode{key_type} and \tcode{mapped_type} are
+\tcode{Key}.
+
+\pnum
+Descriptions are provided here only for operations on \tcode{flat_multiset} that
+are not described in one of those tables or for operations where there is
+additional semantic information.
+
+\pnum
+Any sequence container supporting random access iteration can be used to
+instantiate \tcode{flat_multiset}. In particular, \tcode{vector}\iref{vector}
+and \tcode{deque}\iref{deque} can be used.
+
+\pnum
+The template parameter \tcode{Key} shall denote the same type as
+\tcode{Container::value_type}.
+
+\pnum
+Constructors that take a \tcode{Container} argument \tcode{cont} shall
+participate in overload resolution only if both \tcode{std::begin(cont)} and
+\tcode{std::end(cont)} are well-formed expressions.
+
+\pnum
+The effect of calling a constructor that takes a \tcode{sorted_equivalent_t}
+argument with a range that is not sorted with respect to \tcode{compare} is
+undefined.
+
+\pnum
+Constructors that take an \tcode{Alloc} argument shall participate in overload
+resolution only if \tcode{uses_allocator_v<container_type, Alloc>} is
+\tcode{true}.
+
+\pnum
+Constructors that take an \tcode{Alloc} argument shall participate in overload
+resolution only if \tcode{Alloc} meets the allocator requirements as described
+in \iref{container.requirements.general}.
+
+\rSec3[flatmultiset.defn]{Definition}
 
 \begin{codeblock}
 template <class Key, class Compare = less<Key>, class Container = vector<Key>>
@@ -12326,10 +12391,10 @@ class flat_multiset {
       flat_multiset(sorted_equivalent_t, container_type, const Alloc&)
         : flat_multiset(s, container_type(std::move(cont), a)) { }
     template <class Container>
-      flat_multiset(sorted_unique_t s, const Container& cont)
+      flat_multiset(sorted_equivalent_t s, const Container& cont)
         : flat_multiset(s, cont.begin(), cont.end(), key_compare()) { }
     template <class Container, class Alloc>
-      flat_multiset(sorted_unique_t s, const Container& cont, const Alloc& a)
+      flat_multiset(sorted_equivalent_t s, const Container& cont, const Alloc& a)
         : flat_multiset(s, cont.begin(), cont.end(), key_compare(), a) { }
 
     explicit flat_multiset(const key_compare& comp)

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10159,12 +10159,7 @@ namespace std {
       size_type erase(const key_type& x);
       iterator erase(const_iterator first, const_iterator last);
 
-      void swap(flat_map& fm)
-        noexcept(
-          is_nothrow_swappable_v<key_container_type> &&
-          is_nothrow_swappable_v<mapped_container_type> &&
-          is_nothrow_swappable_v<key_compare>
-        );
+      void swap(flat_map& fm) noexcept;
       void clear() noexcept;
 
       template<class C2>
@@ -10824,6 +10819,7 @@ to \tcode{compare}.
 \pnum \complexity Linear.
 \end{itemdescr}
 
+
 \indexlibrarymember{flatmap}{insert}%
 \begin{itemdecl}
 void insert(sorted_unique_t, initializer_list<pair<key_type, mapped_type>> il);
@@ -10831,6 +10827,29 @@ void insert(sorted_unique_t, initializer_list<pair<key_type, mapped_type>> il);
 
 \begin{itemdescr}
 \pnum Effects: Equivalent to \tcode{insert(sorted_unique_t{}, il.begin(), il.end())}.
+\end{itemdescr}
+
+\indexlibrarymember{flatmap}{swap}%
+\begin{itemdecl}
+void swap(flat_map& fm) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum Effects: Equivalent to:
+\begin{codeblock}
+using std::swap;
+swap(c.keys, fm.c.keys);
+swap(c.values, fm.c.values);
+swap(c.compare, fm.compare);
+\end{codeblock}
+
+\pnum
+\remarks
+This function shall not participate in overload resolution
+unless \tcode{is_nothrow_swappable_v<key_container_type> \&\&
+is_nothrow_swappable_v<mapped_container_type> \&\&
+is_nothrow_swappable_v<key_compare>} is
+\tcode{true}.
 \end{itemdescr}
 
 \indexlibrarymember{flatmap}{extract}%
@@ -10951,7 +10970,8 @@ template<class Key, class T, class Compare, class KeyContainer, class MappedCont
 \pnum
 \remarks
 This function shall not participate in overload resolution
-unless \tcode{is_swappable_v<KeyContainer> \&\& is_swappable_v<MappedContainer>}
+unless \tcode{is_nothrow_swappable_v<KeyContainer> \&\&
+is_nothrow_swappable_v<MappedContainer> \&\& is_nothrow_swappable_v<Compare>}
 is \tcode{true}.
 
 \pnum
@@ -11190,12 +11210,7 @@ namespace std {
       size_type erase(const key_type& x);
       iterator erase(const_iterator first, const_iterator last);
 
-      void swap(flat_multimap& fm)
-        noexcept(
-          is_nothrow_swappable_v<key_container_type> &&
-          is_nothrow_swappable_v<mapped_container_type> &&
-          is_nothrow_swappable_v<key_compare>
-        );
+      void swap(flat_multimap& fm) noexcept;
       void clear() noexcept;
 
       template<class C2>
@@ -11644,6 +11659,29 @@ void insert(sorted_unique_t, initializer_list<pair<key_type, mapped_type>> il);
 \pnum Effects: Equivalent to \tcode{insert(sorted_unique_t{}, il.begin(), il.end())}.
 \end{itemdescr}
 
+\indexlibrarymember{flatmultimap}{swap}%
+\begin{itemdecl}
+void swap(flat_multimap& fm) noexcept;
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum Effects: Equivalent to:
+\begin{codeblock}
+using std::swap;
+swap(c.keys, fm.c.keys);
+swap(c.values, fm.c.values);
+swap(c.compare, fm.compare);
+\end{codeblock}
+
+\pnum
+\remarks
+This function shall not participate in overload resolution
+unless \tcode{is_nothrow_swappable_v<key_container_type> \&\&
+is_nothrow_swappable_v<mapped_container_type> \&\&
+is_nothrow_swappable_v<key_compare>} is
+\tcode{true}.
+\end{itemdescr}
+
 \indexlibrarymember{flatmultimap}{extract}%
 \begin{itemdecl}
 containers extract() &&;
@@ -11762,7 +11800,8 @@ template<class Key, class T, class Compare, class KeyContainer, class MappedCont
 \pnum
 \remarks
 This function shall not participate in overload resolution
-unless \tcode{is_swappable_v<KeyContainer> \&\& is_swappable_v<MappedContainer>}
+unless \tcode{is_nothrow_swappable_v<KeyContainer> \&\&
+is_nothrow_swappable_v<MappedContainer> \&\& is_nothrow_swappable_v<Compare>}
 is \tcode{true}.
 
 \pnum

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10032,7 +10032,7 @@ namespace std {
           : flat_map(s, first, last, key_compare(), a) { }
 
       template <class Alloc>
-        flat_map(const flat_map& m, const Alloc& a)
+        flat_map(flat_map&& m, const Alloc& a)
           : compare{std::move(m.compare)}
           , c{{std::move(m.c.keys), a}, {std::move(m.c.values), a}}
         {}
@@ -11051,7 +11051,7 @@ namespace std {
           : flat_multimap(s, first, last, key_compare(), a) { }
 
       template <class Alloc>
-        flat_multimap(const flat_multimap& m, const Alloc& a)
+        flat_multimap(flat_multimap&& m, const Alloc& a)
           : compare{std::move(m.compare)}
           , c{{std::move(m.c.keys), a}, {std::move(m.c.values), a}}
         {}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -12298,7 +12298,7 @@ with \tcode{std::forward<Args>(args)...}.  If the set already contains an
 element whose key is equivalent to \tcode{t}, there is no effect.  Otherwise,
 equivalent to:
 \begin{codeblock}
-auto it = lower_bound(c.begin(), c.end(), t);
+auto it = std::lower_bound(c.begin(), c.end(), t, compare);
 c.emplace(it, std::move(t));
 \end{codeblock}
 
@@ -12959,7 +12959,7 @@ template <class... Args> iterator emplace(Args&&... args);
 First, constructs a \tcode{key_type} object \tcode{t} constructed
 with \tcode{std::forward<Args>(args)...}, then inserts \tcode{t} as if by:
 \begin{codeblock}
-auto it = upper_bound(c.begin(), c.end(), t);
+auto it = std::upper_bound(c.begin(), c.end(), t, compare);
 c.emplace(it, std::move(t));
 \end{codeblock}
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9992,6 +9992,11 @@ namespace std {
       flat_map();
 
       flat_map(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
+      template <class Alloc>
+      flat_map(key_container_type&& key_cont, mapped_container_type&& mapped_cont,
+               const Alloc& a)
+          : flat_map({std::move(key_cont), a}, {std::move(mapped_cont), a})
+        {}
       template <class Container>
         explicit flat_map(const Container& cont)
           : flat_map(cont.begin(), cont.end(), key_compare()) { }
@@ -10001,6 +10006,11 @@ namespace std {
 
       flat_map(sorted_unique_t,
                key_container_type&& key_cont, mapped_container_type&& mapped_cont);
+      template <class Alloc>
+      flat_map(sorted_unique_t s, key_container_type&& key_cont,
+               mapped_container_type&& mapped_cont, const Alloc& a)
+          : flat_map(s, {std::move(key_cont), a}, {std::move(mapped_cont), a})
+        {}
       template <class Container>
         flat_map(sorted_unique_t s, const Container& cont)
           : flat_map(s, cont.begin(), cont.end(), key_compare()) { }
@@ -11035,6 +11045,11 @@ namespace std {
       flat_multimap();
 
       flat_multimap(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
+      template <class Alloc>
+      flat_multimap(key_container_type&& key_cont, mapped_container_type&& mapped_cont,
+                    const Alloc& a)
+          : flat_map({std::move(key_cont), a}, {std::move(mapped_cont), a})
+        {}
       template <class Container>
         explicit flat_multimap(const Container& cont)
           : flat_multimap(cont.begin(), cont.end(), key_compare()) { }
@@ -11044,6 +11059,11 @@ namespace std {
 
       flat_multimap(sorted_equivalent_t,
                     key_container_type&& key_cont, mapped_container_type&& mapped_cont);
+      template <class Alloc>
+      flat_multimap(sorted_equivalent_t, key_container_type&& key_cont,
+                    mapped_container_type&& mapped_cont, const Alloc& a)
+          : flat_map({std::move(key_cont), a}, {std::move(mapped_cont), a})
+        {}
       template <class Container>
         flat_multimap(sorted_equivalent_t s, const Container& cont)
           : flat_multimap(s, cont.begin(), cont.end(), key_compare()) { }

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9913,6 +9913,26 @@ key value) and provides for fast retrieval of values of another type \tcode{T}
 based on the keys. The \tcode{flat_map} class supports random access
 iterators.
 
+TODO: [[nodiscard]] on empty().
+
+TODO: Front matter should say that it's an invariant that keys and values are
+the same size.  See first part of array overview. time.zone.overview too?
+Also, that the elements are sroted w.r.t. compare.
+
+TODO: Consistently say what happens to keys, values, compare in ctors.
+
+TODO: size() equivalent to keys.size()
+
+TODO: 3) unordered associative container table 72
+
+TODO: 4) say in fron matter that emplace will be used if the underlying containers have them.  Maybe put a paragraph before the modifiers section that says what happens; this an be in terms of a word of power ``INSERT_OR_EMPLACE''  NO! Explain what try_emplace does, though,
+
+TODO: 5) Taken care of by front matter invariants.
+
+TODO: 6) See try_emplace in map.modifiers
+
+
+
 \pnum
 A \tcode{flat_map} satisfies all of the requirements of a container, of a
 reversible container\iref{container.requirements}, and of an associative
@@ -10181,9 +10201,6 @@ namespace std {
       const mapped_container_type& values() const { return c.values; }
 
       // map operations
-      bool contains(const key_type& x) const;
-      template <class K> bool contains(const K& x) const;
-
       iterator find(const key_type& x);
       const_iterator find(const key_type& x) const;
       template <class K> iterator find(const K& x);
@@ -10191,6 +10208,9 @@ namespace std {
 
       size_type count(const key_type& x) const;
       template <class K> size_type count(const K& x) const;
+
+      bool contains(const key_type& x) const;
+      template <class K> bool contains(const K& x) const;
 
       iterator lower_bound(const key_type& x);
       const_iterator lower_bound(const key_type& x) const;
@@ -11191,9 +11211,6 @@ namespace std {
       const mapped_container_type& values() const { return c.values; }
 
       // map operations
-      bool contains(const key_type& x) const;
-      template <class K> bool contains(const K& x) const;
-
       iterator find(const key_type& x);
       const_iterator find(const key_type& x) const;
       template <class K> iterator find(const K& x);
@@ -11201,6 +11218,9 @@ namespace std {
 
       size_type count(const key_type& x) const;
       template <class K> size_type count(const K& x) const;
+
+      bool contains(const key_type& x) const;
+      template <class K> bool contains(const K& x) const;
 
       iterator lower_bound(const key_type& x);
       const_iterator lower_bound(const key_type& x) const;

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -11882,198 +11882,198 @@ namespace std {
   template <class Key, class Compare = less<Key>, class Container = vector<Key>>
   class flat_set {
   public:
-      // types:
-      using key_type                  = Key;
-      using key_compare               = Compare;
-      using value_type                = Key;
-      using value_compare             = Compare;
-      using reference                 = value_type&;
-      using const_reference           = const value_type&;
-      using size_type                 = size_t;
-      using difference_type           = ptrdiff_t;
-      using iterator                  = @\impdefx{type of \tcode{flat_set::iterator}}@; // see \ref{container.requirements}
-      using const_iterator            = @\impdefx{type of \tcode{flat_set::const_iterator}}@; // see \ref{container.requirements}
-      using reverse_iterator          = std::reverse_iterator<iterator>;
-      using const_reverse_iterator    = std::reverse_iterator<const_iterator>;
-      using container_type            = Container;
+    // types:
+    using key_type                  = Key;
+    using key_compare               = Compare;
+    using value_type                = Key;
+    using value_compare             = Compare;
+    using reference                 = value_type&;
+    using const_reference           = const value_type&;
+    using size_type                 = size_t;
+    using difference_type           = ptrdiff_t;
+    using iterator                  = @\impdefx{type of \tcode{flat_set::iterator}}@; // see \ref{container.requirements}
+    using const_iterator            = @\impdefx{type of \tcode{flat_set::const_iterator}}@; // see \ref{container.requirements}
+    using reverse_iterator          = std::reverse_iterator<iterator>;
+    using const_reverse_iterator    = std::reverse_iterator<const_iterator>;
+    using container_type            = Container;
 
-      // \ref{flatset.cons}, construct/copy/destroy
-      flat_set() : flat_set(key_compare()) { }
+    // \ref{flatset.cons}, construct/copy/destroy
+    flat_set() : flat_set(key_compare()) { }
 
-      explicit flat_set(container_type);
-      template <class Alloc>
-        flat_set(container_type cont, const Alloc& a)
-          : flat_set(container_type(std::move(key), a)) { }
-      template <class Container>
-        explicit flat_set(const Container& cont)
-          : flat_set(cont.begin(), cont.end(), key_compare()) { }
-      template <class Container, class Alloc>
-        flat_set(const Container& cont, const Alloc& a)
-          : flat_set(cont.begin(), cont.end(), key_compare(), a) { }
+    explicit flat_set(container_type);
+    template <class Alloc>
+      flat_set(container_type cont, const Alloc& a)
+        : flat_set(container_type(std::move(key), a)) { }
+    template <class Container>
+      explicit flat_set(const Container& cont)
+        : flat_set(cont.begin(), cont.end(), key_compare()) { }
+    template <class Container, class Alloc>
+      flat_set(const Container& cont, const Alloc& a)
+        : flat_set(cont.begin(), cont.end(), key_compare(), a) { }
 
-      flat_set(sorted_unique_t, container_type cont)
-        : c(std::move(cont)), compare(key_compare()) { }
-      template <class Alloc>
-        flat_set(sorted_unique_t s, container_type cont, const Alloc& a)
-          : flat_set(s, key_container_type(std::move(key_cont), a)) { }
-      template <class Container>
-        flat_set(sorted_unique_t s, const Container& cont)
-          : flat_set(s, cont.begin(), cont.end(), key_compare()) { }
-      template <class Container, class Alloc>
-        flat_set(sorted_unique_t s, const Container& cont, const Alloc& a)
-          : flat_set(s, cont.begin(), cont.end(), key_compare(), a) { }
+    flat_set(sorted_unique_t, container_type cont)
+      : c(std::move(cont)), compare(key_compare()) { }
+    template <class Alloc>
+      flat_set(sorted_unique_t s, container_type cont, const Alloc& a)
+        : flat_set(s, key_container_type(std::move(key_cont), a)) { }
+    template <class Container>
+      flat_set(sorted_unique_t s, const Container& cont)
+        : flat_set(s, cont.begin(), cont.end(), key_compare()) { }
+    template <class Container, class Alloc>
+      flat_set(sorted_unique_t s, const Container& cont, const Alloc& a)
+        : flat_set(s, cont.begin(), cont.end(), key_compare(), a) { }
 
-      explicit flat_set(const key_compare& comp)
-        : c(container_type()), compare(comp) { }
-      template <class Alloc>
-        flat_set(const key_compare& comp, const Alloc&);
-      template <class Alloc>
-        explicit flat_set(const Alloc&) 
-          : flat_set(key_compare(), a) { }
+    explicit flat_set(const key_compare& comp)
+      : c(container_type()), compare(comp) { }
+    template <class Alloc>
+      flat_set(const key_compare& comp, const Alloc&);
+    template <class Alloc>
+      explicit flat_set(const Alloc&) 
+        : flat_set(key_compare(), a) { }
 
-      template <class InputIterator>
-        flat_set(InputIterator first, InputIterator last,
-                 const key_compare& comp = key_compare());
-      template <class InputIterator, class Alloc>
-        flat_set(InputIterator first, InputIterator last,
-                 const key_compare& comp, const Alloc&);
-      template <class InputIterator, class Alloc>
-        flat_set(InputIterator first, InputIterator last, const Alloc& a)
-          : flat_set(first, last, key_compare(), a) { }
+    template <class InputIterator>
+      flat_set(InputIterator first, InputIterator last,
+               const key_compare& comp = key_compare());
+    template <class InputIterator, class Alloc>
+      flat_set(InputIterator first, InputIterator last,
+               const key_compare& comp, const Alloc&);
+    template <class InputIterator, class Alloc>
+      flat_set(InputIterator first, InputIterator last, const Alloc& a)
+        : flat_set(first, last, key_compare(), a) { }
 
-      template <class InputIterator>
-        flat_set(sorted_unique_t, InputIterator first, InputIterator last,
-                 const key_compare& comp = key_compare())
-          : c(first, last), compare(comp) { }
-      template <class InputIterator, class Alloc>
-        flat_set(sorted_unique_t, InputIterator first, InputIterator last,
-                 const key_compare& comp, const Alloc&);
-      template <class InputIterator, class Alloc>
-        flat_set(sorted_unique_t s, InputIterator first, InputIterator last,
-                 const Alloc& a)
-          : flat_set(s, first, last, key_compare(), a) { }
-
-      template <class Alloc>
-        flat_set(flat_set&& m, const Alloc& a)
-          : c{container_type(std::move(m.c), a)}
-          , compare{std::move(m.compare)}
-        { }
-      template<class Alloc>
-        flat_set(const flat_set& m, const Alloc& a)
-          : c{container_type(m.c, a)}
-          , compare{m.compare}
-        { }
-
-      flat_set(initializer_list<key_type>&& il,
+    template <class InputIterator>
+      flat_set(sorted_unique_t, InputIterator first, InputIterator last,
                const key_compare& comp = key_compare())
-          : flat_set(il, comp) { }
-      template <class Alloc>
-        flat_set(initializer_list<key_type>&& il,
-                 const key_compare& comp, const Alloc& a)
-          : flat_set(il, comp, a) { }
-      template <class Alloc>
-        flat_set(initializer_list<key_type>&& il, const Alloc& a)
-          : flat_set(il, key_compare(), a) { }
+        : c(first, last), compare(comp) { }
+    template <class InputIterator, class Alloc>
+      flat_set(sorted_unique_t, InputIterator first, InputIterator last,
+               const key_compare& comp, const Alloc&);
+    template <class InputIterator, class Alloc>
+      flat_set(sorted_unique_t s, InputIterator first, InputIterator last,
+               const Alloc& a)
+        : flat_set(s, first, last, key_compare(), a) { }
 
+    template <class Alloc>
+      flat_set(flat_set&& m, const Alloc& a)
+        : c{container_type(std::move(m.c), a)}
+        , compare{std::move(m.compare)}
+      { }
+    template<class Alloc>
+      flat_set(const flat_set& m, const Alloc& a)
+        : c{container_type(m.c, a)}
+        , compare{m.compare}
+      { }
+
+    flat_set(initializer_list<key_type>&& il,
+             const key_compare& comp = key_compare())
+        : flat_set(il, comp) { }
+    template <class Alloc>
+      flat_set(initializer_list<key_type>&& il,
+               const key_compare& comp, const Alloc& a)
+        : flat_set(il, comp, a) { }
+    template <class Alloc>
+      flat_set(initializer_list<key_type>&& il, const Alloc& a)
+        : flat_set(il, key_compare(), a) { }
+
+    flat_set(sorted_unique_t s, initializer_list<key_type>&& il,
+             const key_compare& comp = key_compare()) 
+        : flat_set(s ,il, comp) { }
+    template <class Alloc>
       flat_set(sorted_unique_t s, initializer_list<key_type>&& il,
-               const key_compare& comp = key_compare()) 
-          : flat_set(s ,il, comp) { }
-      template <class Alloc>
-        flat_set(sorted_unique_t s, initializer_list<key_type>&& il,
-                 const key_compare& comp, const Alloc& a) 
-          : flat_set(s, il, comp, a) { }
-      template <class Alloc>
-        flat_set(sorted_unique_t s, initializer_list<key_type>&& il,
-                 const Alloc& a)
-          : flat_set(s, il, key_compare(), a) { }
+               const key_compare& comp, const Alloc& a) 
+        : flat_set(s, il, comp, a) { }
+    template <class Alloc>
+      flat_set(sorted_unique_t s, initializer_list<key_type>&& il,
+               const Alloc& a)
+        : flat_set(s, il, key_compare(), a) { }
 
-      flat_set& operator=(initializer_list<key_type>);
-  
-      // iterators
-      iterator               begin() noexcept;
-      const_iterator         begin() const noexcept;
-      iterator               end() noexcept;
-      const_iterator         end() const noexcept;
+    flat_set& operator=(initializer_list<key_type>);
 
-      reverse_iterator       rbegin() noexcept;
-      const_reverse_iterator rbegin() const noexcept;
-      reverse_iterator       rend() noexcept;
-      const_reverse_iterator rend() const noexcept;
+    // iterators
+    iterator               begin() noexcept;
+    const_iterator         begin() const noexcept;
+    iterator               end() noexcept;
+    const_iterator         end() const noexcept;
 
-      const_iterator         cbegin() const noexcept;
-      const_iterator         cend() const noexcept;
-      const_reverse_iterator crbegin() const noexcept;
-      const_reverse_iterator crend() const noexcept;
+    reverse_iterator       rbegin() noexcept;
+    const_reverse_iterator rbegin() const noexcept;
+    reverse_iterator       rend() noexcept;
+    const_reverse_iterator rend() const noexcept;
 
-      // \ref{flatset.capacity}, capacity
-      [[nodiscard]] bool empty() const noexcept;
-      size_type size() const noexcept;
-      size_type max_size() const noexcept;
+    const_iterator         cbegin() const noexcept;
+    const_iterator         cend() const noexcept;
+    const_reverse_iterator crbegin() const noexcept;
+    const_reverse_iterator crend() const noexcept;
 
-      // \ref{flatset.modifiers}, modifiers
-      template <class... Args> pair<iterator, bool> emplace(Args&&... args);
-      template <class... Args>
-        iterator emplace_hint(const_iterator position, Args&&... args);
-      pair<iterator, bool> insert(const value_type& x);
-      pair<iterator, bool> insert(value_type&& x);
-      iterator insert(const_iterator position, const value_type& x);
-      iterator insert(const_iterator position, value_type&& x);
-      template <class InputIterator>
-        void insert(InputIterator first, InputIterator last);
-      template <class InputIterator>
-        void insert(sorted_unique_t, InputIterator first, InputIterator last);
-      void insert(initializer_list<key_type>);
-      void insert(sorted_unique_t, initializer_list<key_type>);
+    // \ref{flatset.capacity}, capacity
+    [[nodiscard]] bool empty() const noexcept;
+    size_type size() const noexcept;
+    size_type max_size() const noexcept;
 
-      container_type extract() &&;
-      void replace(container_type&&);
+    // \ref{flatset.modifiers}, modifiers
+    template <class... Args> pair<iterator, bool> emplace(Args&&... args);
+    template <class... Args>
+      iterator emplace_hint(const_iterator position, Args&&... args);
+    pair<iterator, bool> insert(const value_type& x);
+    pair<iterator, bool> insert(value_type&& x);
+    iterator insert(const_iterator position, const value_type& x);
+    iterator insert(const_iterator position, value_type&& x);
+    template <class InputIterator>
+      void insert(InputIterator first, InputIterator last);
+    template <class InputIterator>
+      void insert(sorted_unique_t, InputIterator first, InputIterator last);
+    void insert(initializer_list<key_type>);
+    void insert(sorted_unique_t, initializer_list<key_type>);
 
-      iterator erase(iterator position);
-      iterator erase(const_iterator position);
-      size_type erase(const key_type& x);
-      iterator erase(const_iterator first, const_iterator last);
+    container_type extract() &&;
+    void replace(container_type&&);
 
-      void swap(flat_set& fs) noexcept(
-        is_nothrow_swappable_v<container_type> && is_nothrow_swappable_v<key_compare>
-      );
-      void clear() noexcept;
+    iterator erase(iterator position);
+    iterator erase(const_iterator position);
+    size_type erase(const key_type& x);
+    iterator erase(const_iterator first, const_iterator last);
 
-      // observers
-      key_compare key_comp() const;
-      value_compare value_comp() const;
-  
-      // set operations
-      iterator find(const key_type& x);
-      const_iterator find(const key_type& x) const;
-      template <class K> iterator find(const K& x);
-      template <class K> const_iterator find(const K& x) const;
+    void swap(flat_set& fs) noexcept(
+      is_nothrow_swappable_v<container_type> && is_nothrow_swappable_v<key_compare>
+    );
+    void clear() noexcept;
 
-      size_type count(const key_type& x) const;
-      template <class K> size_type count(const K& x) const;
+    // observers
+    key_compare key_comp() const;
+    value_compare value_comp() const;
 
-      bool contains(const key_type& x) const;
-      template <class K> bool contains(const K& x) const;
+    // set operations
+    iterator find(const key_type& x);
+    const_iterator find(const key_type& x) const;
+    template <class K> iterator find(const K& x);
+    template <class K> const_iterator find(const K& x) const;
 
-      iterator lower_bound(const key_type& x);
-      const_iterator lower_bound(const key_type& x) const;
-      template <class K> iterator lower_bound(const K& x);
-      template <class K> const_iterator lower_bound(const K& x) const;
+    size_type count(const key_type& x) const;
+    template <class K> size_type count(const K& x) const;
 
-      iterator upper_bound(const key_type& x);
-      const_iterator upper_bound(const key_type& x) const;
-      template <class K> iterator upper_bound(const K& x);
-      template <class K> const_iterator upper_bound(const K& x) const;
+    bool contains(const key_type& x) const;
+    template <class K> bool contains(const K& x) const;
 
-      pair<iterator, iterator> equal_range(const key_type& x);
-      pair<const_iterator, const_iterator> equal_range(const key_type& x) const;
-      template <class K>
-        pair<iterator, iterator> equal_range(const K& x);
-      template <class K>
-        pair<const_iterator, const_iterator> equal_range(const K& x) const;
+    iterator lower_bound(const key_type& x);
+    const_iterator lower_bound(const key_type& x) const;
+    template <class K> iterator lower_bound(const K& x);
+    template <class K> const_iterator lower_bound(const K& x) const;
 
-    private:
-        container_type c;    // \expos
-        key_compare compare; // \expos
+    iterator upper_bound(const key_type& x);
+    const_iterator upper_bound(const key_type& x) const;
+    template <class K> iterator upper_bound(const K& x);
+    template <class K> const_iterator upper_bound(const K& x) const;
+
+    pair<iterator, iterator> equal_range(const key_type& x);
+    pair<const_iterator, const_iterator> equal_range(const key_type& x) const;
+    template <class K>
+      pair<iterator, iterator> equal_range(const K& x);
+    template <class K>
+      pair<const_iterator, const_iterator> equal_range(const K& x) const;
+
+  private:
+      container_type c;    // \expos
+      key_compare compare; // \expos
   };
 
   template <class Container>
@@ -12291,199 +12291,199 @@ Linear.
 template <class Key, class Compare = less<Key>, class Container = vector<Key>>
 class flat_multiset {
   public:
-      // types
-      using key_type                  = Key;
-      using key_compare               = Compare;
-      using value_type                = Key;
-      using value_compare             = Compare;
-      using reference                 = value_type&;
-      using const_reference           = const value_type&;
-      using size_type                 = size_t;
-      using difference_type           = ptrdiff_t;
-      using iterator                  = @\impdefx{type of \tcode{flat_multiset::iterator}}@; // see \ref{container.requirements}
-      using const_iterator            = @\impdefx{type of \tcode{flat_multiset::const_iterator}}@; // see \ref{container.requirements}
-      using reverse_iterator          = std::reverse_iterator<iterator>;
-      using const_reverse_iterator    = std::reverse_iterator<const_iterator>;
-      using container_type            = Container;
+    // types
+    using key_type                  = Key;
+    using key_compare               = Compare;
+    using value_type                = Key;
+    using value_compare             = Compare;
+    using reference                 = value_type&;
+    using const_reference           = const value_type&;
+    using size_type                 = size_t;
+    using difference_type           = ptrdiff_t;
+    using iterator                  = @\impdefx{type of \tcode{flat_multiset::iterator}}@; // see \ref{container.requirements}
+    using const_iterator            = @\impdefx{type of \tcode{flat_multiset::const_iterator}}@; // see \ref{container.requirements}
+    using reverse_iterator          = std::reverse_iterator<iterator>;
+    using const_reverse_iterator    = std::reverse_iterator<const_iterator>;
+    using container_type            = Container;
 
-      // \ref{flatmultiset.cons}, construct/copy/destroy
-      flat_multiset() : flat_multiset(key_compare()) { }
+    // \ref{flatmultiset.cons}, construct/copy/destroy
+    flat_multiset() : flat_multiset(key_compare()) { }
 
-      explicit flat_multiset(container_type cont);
-      template <class Alloc>
-        flat_multiset(container_type cont, const Alloc& a)
-          : flat_multiset(container_type(std::move(key), a)) { }
-      template <class Container>
-        explicit flat_multiset(const Container& cont)
-          : flat_multiset(cont.begin(), cont.end(), key_compare()) { }
-      template <class Container, class Alloc>
-        flat_multiset(const Container& cont, const Alloc& a)
-          : flat_multiset(cont.begin(), cont.end(), key_compare(), a) { }
+    explicit flat_multiset(container_type cont);
+    template <class Alloc>
+      flat_multiset(container_type cont, const Alloc& a)
+        : flat_multiset(container_type(std::move(key), a)) { }
+    template <class Container>
+      explicit flat_multiset(const Container& cont)
+        : flat_multiset(cont.begin(), cont.end(), key_compare()) { }
+    template <class Container, class Alloc>
+      flat_multiset(const Container& cont, const Alloc& a)
+        : flat_multiset(cont.begin(), cont.end(), key_compare(), a) { }
 
-      flat_multiset(sorted_equivalent_t, container_type cont)
-        : c(std::move(cont)), compare(key_compare()) { }
-      template <class Alloc>
-        flat_multiset(sorted_equivalent_t, container_type, const Alloc&)
-          : flat_multiset(s, container_type(std::move(cont), a)) { }
-      template <class Container>
-        flat_multiset(sorted_unique_t s, const Container& cont)
-          : flat_multiset(s, cont.begin(), cont.end(), key_compare()) { }
-      template <class Container, class Alloc>
-        flat_multiset(sorted_unique_t s, const Container& cont, const Alloc& a)
-          : flat_multiset(s, cont.begin(), cont.end(), key_compare(), a) { }
+    flat_multiset(sorted_equivalent_t, container_type cont)
+      : c(std::move(cont)), compare(key_compare()) { }
+    template <class Alloc>
+      flat_multiset(sorted_equivalent_t, container_type, const Alloc&)
+        : flat_multiset(s, container_type(std::move(cont), a)) { }
+    template <class Container>
+      flat_multiset(sorted_unique_t s, const Container& cont)
+        : flat_multiset(s, cont.begin(), cont.end(), key_compare()) { }
+    template <class Container, class Alloc>
+      flat_multiset(sorted_unique_t s, const Container& cont, const Alloc& a)
+        : flat_multiset(s, cont.begin(), cont.end(), key_compare(), a) { }
 
-      explicit flat_multiset(const key_compare& comp)
-        : c(container_type()), compare(comp) { }
-      template <class Alloc>
-        flat_multiset(const key_compare& comp, const Alloc&);
-      template <class Alloc>
-        explicit flat_multiset(const Alloc& a)
-          : flat_multiset(key_compare(), a) { }
+    explicit flat_multiset(const key_compare& comp)
+      : c(container_type()), compare(comp) { }
+    template <class Alloc>
+      flat_multiset(const key_compare& comp, const Alloc&);
+    template <class Alloc>
+      explicit flat_multiset(const Alloc& a)
+        : flat_multiset(key_compare(), a) { }
 
-      template <class InputIterator>
-        flat_multiset(InputIterator first, InputIterator last,
-                      const key_compare& comp = key_compare());
-      template <class InputIterator, class Alloc>
-        flat_multiset(InputIterator first, InputIterator last,
-                      const key_compare& comp, const Alloc&);
-      template <class InputIterator, class Alloc>
-        flat_multiset(InputIterator first, InputIterator last,
-                      const Alloc& a)
-          : flat_multiset(first, last, key_compare(), a) { }
+    template <class InputIterator>
+      flat_multiset(InputIterator first, InputIterator last,
+                    const key_compare& comp = key_compare());
+    template <class InputIterator, class Alloc>
+      flat_multiset(InputIterator first, InputIterator last,
+                    const key_compare& comp, const Alloc&);
+    template <class InputIterator, class Alloc>
+      flat_multiset(InputIterator first, InputIterator last,
+                    const Alloc& a)
+        : flat_multiset(first, last, key_compare(), a) { }
 
-      template <class InputIterator>
-        flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
-                      const key_compare& comp = key_compare())
-          : c(first, last), compare(comp) { }
-      template <class InputIterator, class Alloc>
-        flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
-                      const key_compare& comp, const Alloc&);
-      template <class InputIterator, class Alloc>
-        flat_multiset(sorted_equivalent_t s, InputIterator first, InputIterator last,
-                      const Alloc& a)
-          : flat_multiset(s, first, last, key_compare(), a) { }
+    template <class InputIterator>
+      flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
+                    const key_compare& comp = key_compare())
+        : c(first, last), compare(comp) { }
+    template <class InputIterator, class Alloc>
+      flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
+                    const key_compare& comp, const Alloc&);
+    template <class InputIterator, class Alloc>
+      flat_multiset(sorted_equivalent_t s, InputIterator first, InputIterator last,
+                    const Alloc& a)
+        : flat_multiset(s, first, last, key_compare(), a) { }
 
-      template <class Alloc>
-       flat_multiset(flat_multiset&& m, const Alloc& a)
-         : c{container_type(std::move(m.c), a)}
-         , compare{std::move(m.compare)}
-       { }
-     template<class Alloc>
-       flat_multiset(const flat_multiset& m, const Alloc& a)
-         : c{container_type(m.c, a)}
-         , compare{m.compare}
-       { }
+    template <class Alloc>
+     flat_multiset(flat_multiset&& m, const Alloc& a)
+       : c{container_type(std::move(m.c), a)}
+       , compare{std::move(m.compare)}
+     { }
+   template<class Alloc>
+     flat_multiset(const flat_multiset& m, const Alloc& a)
+       : c{container_type(m.c, a)}
+       , compare{m.compare}
+     { }
 
+    flat_multiset(initializer_list<key_type>&& il,
+                  const key_compare& comp = key_compare())
+      : flat_multiset(il, comp) { }
+    template <class Alloc>
       flat_multiset(initializer_list<key_type>&& il,
-                    const key_compare& comp = key_compare())
-        : flat_multiset(il, comp) { }
-      template <class Alloc>
-        flat_multiset(initializer_list<key_type>&& il,
-                      const key_compare& comp, const Alloc& a)
-          : flat_multiset(il, comp, a) { }
-      template <class Alloc>
-        flat_multiset(initializer_list<key_type>&& il, const Alloc& a)
-          : flat_multiset(il, key_compare(), a) { }
+                    const key_compare& comp, const Alloc& a)
+        : flat_multiset(il, comp, a) { }
+    template <class Alloc>
+      flat_multiset(initializer_list<key_type>&& il, const Alloc& a)
+        : flat_multiset(il, key_compare(), a) { }
 
+    flat_multiset(sorted_equivalent_t s, initializer_list<key_type>&& il,
+                  const key_compare& comp = key_compare())
+        : flat_multiset(s, il, comp) { }
+    template <class Alloc>
       flat_multiset(sorted_equivalent_t s, initializer_list<key_type>&& il,
-                    const key_compare& comp = key_compare())
-          : flat_multiset(s, il, comp) { }
-      template <class Alloc>
-        flat_multiset(sorted_equivalent_t s, initializer_list<key_type>&& il,
-                      const key_compare& comp, const Alloc& a)
-          : flat_multiset(s, il, comp, a) { }
-      template <class Alloc>
-        flat_multiset(sorted_equivalent_t s, initializer_list<key_type>&& il,
-                      const Alloc& a)
-          : flat_multiset(s, il, key_compare(), a) { }
+                    const key_compare& comp, const Alloc& a)
+        : flat_multiset(s, il, comp, a) { }
+    template <class Alloc>
+      flat_multiset(sorted_equivalent_t s, initializer_list<key_type>&& il,
+                    const Alloc& a)
+        : flat_multiset(s, il, key_compare(), a) { }
 
-      flat_multiset& operator=(initializer_list<key_type>);
+    flat_multiset& operator=(initializer_list<key_type>);
 
-      // iterators
-      iterator               begin() noexcept;
-      const_iterator         begin() const noexcept;
-      iterator               end() noexcept;
-      const_iterator         end() const noexcept;
+    // iterators
+    iterator               begin() noexcept;
+    const_iterator         begin() const noexcept;
+    iterator               end() noexcept;
+    const_iterator         end() const noexcept;
 
-      reverse_iterator       rbegin() noexcept;
-      const_reverse_iterator rbegin() const noexcept;
-      reverse_iterator       rend() noexcept;
-      const_reverse_iterator rend() const noexcept;
+    reverse_iterator       rbegin() noexcept;
+    const_reverse_iterator rbegin() const noexcept;
+    reverse_iterator       rend() noexcept;
+    const_reverse_iterator rend() const noexcept;
 
-      const_iterator         cbegin() const noexcept;
-      const_iterator         cend() const noexcept;
-      const_reverse_iterator crbegin() const noexcept;
-      const_reverse_iterator crend() const noexcept;
+    const_iterator         cbegin() const noexcept;
+    const_iterator         cend() const noexcept;
+    const_reverse_iterator crbegin() const noexcept;
+    const_reverse_iterator crend() const noexcept;
 
-      // \ref{flatmultiset.capacity}, capacity
-      [[nodiscard]] bool empty() const noexcept;
-      size_type size() const noexcept;
-      size_type max_size() const noexcept;
+    // \ref{flatmultiset.capacity}, capacity
+    [[nodiscard]] bool empty() const noexcept;
+    size_type size() const noexcept;
+    size_type max_size() const noexcept;
 
-      // \ref{flatmultiset.modifiers}, modifiers
-      template <class... Args> iterator emplace(Args&&... args);
-      template <class... Args>
-        iterator emplace_hint(const_iterator position, Args&&... args);
-      iterator insert(const value_type& x);
-      iterator insert(value_type&& x);
-      iterator insert(const_iterator position, const value_type& x);
-      iterator insert(const_iterator position, value_type&& x);
-      template <class InputIterator>
-        void insert(InputIterator first, InputIterator last);
-      template <class InputIterator>
-        void insert(sorted_equivalent_t, InputIterator first, InputIterator last);
-      void insert(initializer_list<key_type>);
-      void insert(sorted_equivalent_t, initializer_list<key_type>);
+    // \ref{flatmultiset.modifiers}, modifiers
+    template <class... Args> iterator emplace(Args&&... args);
+    template <class... Args>
+      iterator emplace_hint(const_iterator position, Args&&... args);
+    iterator insert(const value_type& x);
+    iterator insert(value_type&& x);
+    iterator insert(const_iterator position, const value_type& x);
+    iterator insert(const_iterator position, value_type&& x);
+    template <class InputIterator>
+      void insert(InputIterator first, InputIterator last);
+    template <class InputIterator>
+      void insert(sorted_equivalent_t, InputIterator first, InputIterator last);
+    void insert(initializer_list<key_type>);
+    void insert(sorted_equivalent_t, initializer_list<key_type>);
 
-      container_type extract() &&;
-      void replace(container_type&&);
+    container_type extract() &&;
+    void replace(container_type&&);
 
-      iterator erase(iterator position);
-      iterator erase(const_iterator position);
-      size_type erase(const key_type& x);
-      iterator erase(const_iterator first, const_iterator last);
+    iterator erase(iterator position);
+    iterator erase(const_iterator position);
+    size_type erase(const key_type& x);
+    iterator erase(const_iterator first, const_iterator last);
 
-      void swap(flat_multiset& fms) noexcept(
-          is_nothrow_swappable_v<container_type> && is_nothrow_swappable_v<key_compare>
-      );
-      void clear() noexcept;
+    void swap(flat_multiset& fms) noexcept(
+        is_nothrow_swappable_v<container_type> && is_nothrow_swappable_v<key_compare>
+    );
+    void clear() noexcept;
 
-      // observers
-      key_compare key_comp() const;
-      value_compare value_comp() const;
+    // observers
+    key_compare key_comp() const;
+    value_compare value_comp() const;
 
-      // set operations
-      iterator find(const key_type& x);
-      const_iterator find(const key_type& x) const;
-      template <class K> iterator find(const K& x);
-      template <class K> const_iterator find(const K& x) const;
+    // set operations
+    iterator find(const key_type& x);
+    const_iterator find(const key_type& x) const;
+    template <class K> iterator find(const K& x);
+    template <class K> const_iterator find(const K& x) const;
 
-      size_type count(const key_type& x) const;
-      template <class K> size_type count(const K& x) const;
+    size_type count(const key_type& x) const;
+    template <class K> size_type count(const K& x) const;
 
-      bool contains(const key_type& x) const;
-      template <class K> bool contains(const K& x) const;
+    bool contains(const key_type& x) const;
+    template <class K> bool contains(const K& x) const;
 
-      iterator lower_bound(const key_type& x);
-      const_iterator lower_bound(const key_type& x) const;
-      template <class K> iterator lower_bound(const K& x);
-      template <class K> const_iterator lower_bound(const K& x) const;
+    iterator lower_bound(const key_type& x);
+    const_iterator lower_bound(const key_type& x) const;
+    template <class K> iterator lower_bound(const K& x);
+    template <class K> const_iterator lower_bound(const K& x) const;
 
-      iterator upper_bound(const key_type& x);
-      const_iterator upper_bound(const key_type& x) const;
-      template <class K> iterator upper_bound(const K& x);
-      template <class K> const_iterator upper_bound(const K& x) const;
+    iterator upper_bound(const key_type& x);
+    const_iterator upper_bound(const key_type& x) const;
+    template <class K> iterator upper_bound(const K& x);
+    template <class K> const_iterator upper_bound(const K& x) const;
 
-      pair<iterator, iterator> equal_range(const key_type& x);
-      pair<const_iterator, const_iterator> equal_range(const key_type& x) const;
-      template <class K>
-        pair<iterator, iterator> equal_range(const K& x);
-      template <class K>
-        pair<const_iterator, const_iterator> equal_range(const K& x) const;
+    pair<iterator, iterator> equal_range(const key_type& x);
+    pair<const_iterator, const_iterator> equal_range(const key_type& x) const;
+    template <class K>
+      pair<iterator, iterator> equal_range(const K& x);
+    template <class K>
+      pair<const_iterator, const_iterator> equal_range(const K& x) const;
 
-    private:
-        container_type c;    // \expos
-        key_compare compare; // \expos
+  private:
+      container_type c;    // \expos
+      key_compare compare; // \expos
   };
 
   template <class Container>

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9995,7 +9995,8 @@ namespace std {
       template <class Alloc>
       flat_map(key_container_type&& key_cont, mapped_container_type&& mapped_cont,
                const Alloc& a)
-          : flat_map({std::move(key_cont), a}, {std::move(mapped_cont), a})
+          : flat_map(key_container_type(std::move(key_cont), a),
+                     mapped_container_type(std::move(mapped_cont), a))
         {}
       template <class Container>
         explicit flat_map(const Container& cont)
@@ -10009,7 +10010,8 @@ namespace std {
       template <class Alloc>
       flat_map(sorted_unique_t s, key_container_type&& key_cont,
                mapped_container_type&& mapped_cont, const Alloc& a)
-          : flat_map(s, {std::move(key_cont), a}, {std::move(mapped_cont), a})
+          : flat_map(s, key_container_type(std::move(key_cont), a),
+                     mapped_container_type(std::move(mapped_cont), a))
         {}
       template <class Container>
         flat_map(sorted_unique_t s, const Container& cont)
@@ -10050,12 +10052,14 @@ namespace std {
       template <class Alloc>
         flat_map(flat_map&& m, const Alloc& a)
           : compare{std::move(m.compare)}
-          , c{{std::move(m.c.keys), a}, {std::move(m.c.values), a}}
+          , c{key_container_type(std::move(m.c.keys), a),
+              mapped_container_type(std::move(m.c.values), a)}
         {}
       template<class Alloc>
         flat_map(const flat_map& m, const Alloc& a)
           : compare{m.compare}
-          , c{{m.c.keys, a}, {m.c.values, a}}
+          , c{key_container_type(m.c.keys, a),
+              mapped_container_type(m.c.values, a)}
         {}
 
       flat_map(initializer_list<pair<key_type, mapped_type>>&& il,
@@ -11048,7 +11052,8 @@ namespace std {
       template <class Alloc>
       flat_multimap(key_container_type&& key_cont, mapped_container_type&& mapped_cont,
                     const Alloc& a)
-          : flat_map({std::move(key_cont), a}, {std::move(mapped_cont), a})
+          : flat_map(key_container_type(std::move(key_cont), a),
+                     mapped_container_type(std::move(mapped_cont), a))
         {}
       template <class Container>
         explicit flat_multimap(const Container& cont)
@@ -11062,7 +11067,8 @@ namespace std {
       template <class Alloc>
       flat_multimap(sorted_equivalent_t, key_container_type&& key_cont,
                     mapped_container_type&& mapped_cont, const Alloc& a)
-          : flat_map({std::move(key_cont), a}, {std::move(mapped_cont), a})
+          : flat_map(key_container_type(std::move(key_cont), a),
+                     mapped_container_type(std::move(mapped_cont), a))
         {}
       template <class Container>
         flat_multimap(sorted_equivalent_t s, const Container& cont)
@@ -11103,12 +11109,13 @@ namespace std {
       template <class Alloc>
         flat_multimap(flat_multimap&& m, const Alloc& a)
           : compare{std::move(m.compare)}
-          , c{{std::move(m.c.keys), a}, {std::move(m.c.values), a}}
+          , c{key_container_type(std::move(m.c.keys), a),
+              mapped_container_type(std::move(m.c.values), a)}
         {}
       template<class Alloc>
         flat_multimap(const flat_multimap& m, const Alloc& a)
           : compare{m.compare}
-          , c{{m.c.keys, a}, {m.c.values, a}}
+          , c{key_container_type(m.c.keys, a), mapped_container_type(m.c.values, a)}
         {}
 
       flat_multimap(initializer_list<pair<key_type, mapped_type>>&& il,

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -11898,19 +11898,38 @@ namespace std {
       using container_type            = Container;
 
       // \ref{flatset.cons}, construct/copy/destroy
-      flat_set();
+      flat_set() : flat_set(key_compare()) { }
 
       explicit flat_set(container_type);
       template <class Alloc>
-        flat_set(container_type, const Alloc&);
-      flat_set(sorted_unique_t, container_type);
+        flat_set(container_type cont, const Alloc& a)
+          : flat_set(container_type(std::move(key), a)) { }
+      template <class Container>
+        explicit flat_set(const Container& cont)
+          : flat_set(cont.begin(), cont.end(), key_compare()) { }
+      template <class Container, class Alloc>
+        flat_set(const Container& cont, const Alloc& a)
+          : flat_set(cont.begin(), cont.end(), key_compare(), a) { }
+
+      flat_set(sorted_unique_t, container_type cont)
+        : c(std::move(cont)), compare(key_compare()) { }
       template <class Alloc>
-        flat_set(sorted_unique_t, container_type, const Alloc&);
-      explicit flat_set(const key_compare& comp);
+        flat_set(sorted_unique_t s, container_type cont, const Alloc& a)
+          : flat_set(s, key_container_type(std::move(key_cont), a)) { }
+      template <class Container>
+        flat_set(sorted_unique_t s, const Container& cont)
+          : flat_set(s, cont.begin(), cont.end(), key_compare()) { }
+      template <class Container, class Alloc>
+        flat_set(sorted_unique_t s, const Container& cont, const Alloc& a)
+          : flat_set(s, cont.begin(), cont.end(), key_compare(), a) { }
+
+      explicit flat_set(const key_compare& comp)
+        : c(container_type()), compare(comp) { }
       template <class Alloc>
         flat_set(const key_compare& comp, const Alloc&);
       template <class Alloc>
-        explicit flat_set(const Alloc&);
+        explicit flat_set(const Alloc&) 
+          : flat_set(key_compare(), a) { }
 
       template <class InputIterator>
         flat_set(InputIterator first, InputIterator last,
@@ -11924,33 +11943,49 @@ namespace std {
 
       template <class InputIterator>
         flat_set(sorted_unique_t, InputIterator first, InputIterator last,
-                 const key_compare& comp = key_compare());
+                 const key_compare& comp = key_compare())
+          : c(first, last), compare(comp) { }
       template <class InputIterator, class Alloc>
         flat_set(sorted_unique_t, InputIterator first, InputIterator last,
                  const key_compare& comp, const Alloc&);
       template <class InputIterator, class Alloc>
-        flat_set(sorted_unique_t t, InputIterator first, InputIterator last,
+        flat_set(sorted_unique_t s, InputIterator first, InputIterator last,
                  const Alloc& a)
-          : flat_set(t, first, last, key_compare(), a) { }
-      template <class Alloc>
-        flat_set(flat_set, const Alloc&);
+          : flat_set(s, first, last, key_compare(), a) { }
 
-      flat_set(initializer_list<key_type>, const key_compare& = key_compare());
       template <class Alloc>
-        flat_set(initializer_list<key_type>, const key_compare&, const Alloc&);
+        flat_set(flat_set&& m, const Alloc& a)
+          : c{container_type(std::move(m.c), a)}
+          , compare{std::move(m.compare)}
+        { }
+      template<class Alloc>
+        flat_set(const flat_set& m, const Alloc& a)
+          : c{container_type(m.c, a)}
+          , compare{m.compare}
+        { }
+
+      flat_set(initializer_list<key_type>&& il,
+               const key_compare& comp = key_compare())
+          : flat_set(il, comp) { }
       template <class Alloc>
-        flat_set(initializer_list<key_type> il, const Alloc& a)
+        flat_set(initializer_list<key_type>&& il,
+                 const key_compare& comp, const Alloc& a)
+          : flat_set(il, comp, a) { }
+      template <class Alloc>
+        flat_set(initializer_list<key_type>&& il, const Alloc& a)
           : flat_set(il, key_compare(), a) { }
 
-      flat_set(sorted_unique_t, initializer_list<key_type>,
-               const key_compare& = key_compare());
+      flat_set(sorted_unique_t s, initializer_list<key_type>&& il,
+               const key_compare& comp = key_compare()) 
+          : flat_set(s ,il, comp) { }
       template <class Alloc>
-        flat_set(sorted_unique_t, initializer_list<key_type>,
-                 const key_compare&, const Alloc&);
+        flat_set(sorted_unique_t s, initializer_list<key_type>&& il,
+                 const key_compare& comp, const Alloc& a) 
+          : flat_set(s, il, comp, a) { }
       template <class Alloc>
-        flat_set(sorted_unique_t t, initializer_list<key_type> il,
+        flat_set(sorted_unique_t s, initializer_list<key_type>&& il,
                  const Alloc& a)
-          : flat_set(t, il, key_compare(), a) { }
+          : flat_set(s, il, key_compare(), a) { }
 
       flat_set& operator=(initializer_list<key_type>);
   
@@ -12035,6 +12070,10 @@ namespace std {
         pair<iterator, iterator> equal_range(const K& x);
       template <class K>
         pair<const_iterator, const_iterator> equal_range(const K& x) const;
+
+    private:
+        container_type c;    // \expos
+        key_compare compare; // \expos
   };
 
   template <class Container>
@@ -12125,7 +12164,128 @@ namespace std {
 }
 \end{codeblock}
 
-TODO
+\rSec3[flatset.cons]{Constructors}
+
+\indexlibrary{\idxcode{flatset}!constructor}%
+\begin{itemdecl}
+flat_set(container_type cont);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Initializes \tcode{c} with \tcode{std::move(cont)}; value-initializes
+\tcode{compare}; and sorts the range \range{begin()}{end()} with
+\tcode{compare}.
+
+\pnum
+\complexity
+Linear in $N$ if \tcode{cont} is sorted as if with \tcode{compare} and
+otherwise $N \log N$, where $N$ is \tcode{cont.size()}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{flatset}!constructor}%
+\begin{itemdecl}
+template <class InputIterator>
+  flat_set(InputIterator first, InputIterator last, const key_compare& comp);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Initializes \tcode{compare} with \tcode{comp}, initializes \tcode{c}
+with \range{first}{last}, and finally sorts the range \range{begin()}{end()}
+with \tcode{compare}.
+
+\pnum
+\complexity
+Linear in $N$ if \tcode{cont} is already sorted as if with \tcode{compare} and
+otherwise $N \log N$, where $N$ is \tcode{distance(first, last)}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{flatset}!constructor}%
+\begin{itemdecl}
+template <class InputIterator>
+  flat_set(sorted_unique_t, InputIterator first, InputIterator last,
+           const key_compare& comp = key_compare());
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Initializes \tcode{compare} with \tcode{comp}, and initializes
+\tcode{c} from \range{first}{last}.
+
+\pnum
+\complexity
+Linear.
+\end{itemdescr}
+
+\rSec3[flatset.cons.alloc]{Constructors with allocators}
+
+\indexlibrary{\idxcode{flatset}!constructor}%
+\begin{itemdecl}
+template <class Alloc>
+  flat_set(const key_compare& comp, const Alloc& a);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Initializes \tcode{compare} with \tcode{comp}, and performs
+uses-allocator construction\iref{allocator.uses.construction} of
+\tcode{c} with \tcode{a}.
+
+\pnum
+\complexity
+Constant.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{flatset}!constructor}%
+\begin{itemdecl}
+template <class InputIterator, class Alloc>
+  flat_set(InputIterator first, InputIterator last,
+           const key_compare& comp, const Alloc& a);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Initializes \tcode{compare} with \tcode{comp}, and performs
+uses-allocator construction\iref{allocator.uses.construction} of \tcode{c}
+with \tcode{a}; adds elements to \tcode{c} as if by:
+\begin{codeblock}
+for (; first != last; ++first) {
+  c.insert(c.end(), *first);
+}
+\end{codeblock}
+and finally sorts the range \range{begin()}{end()} with \tcode{compare}.
+
+\pnum
+\complexity
+Linear in $N$ if \tcode{cont} is sorted as if with \tcode{compare} and
+otherwise $N \log N$, where $N$ is \tcode{distance(first, last)}.
+\end{itemdescr}
+
+\indexlibrary{\idxcode{flatset}!constructor}%
+\begin{itemdecl}
+template <class InputIterator, class Alloc>
+  flat_set(sorted_unique_t, InputIterator first, InputIterator last,
+           const key_compare& comp, const Alloc& a);
+\end{itemdecl}
+
+\begin{itemdescr}
+\pnum
+\effects Initializes \tcode{compare} with \tcode{comp}, and performs
+uses-allocator construction\iref{allocator.uses.construction} of \tcode{c}
+with \tcode{a}; adds elements to \tcode{c} as if by:
+\begin{codeblock}
+for (; first != last; ++first) {
+  c.insert(c.end(), *first);
+}
+\end{codeblock}
+
+\pnum
+\complexity
+Linear.
+\end{itemdescr}
+
+\rSec3[flatset.modifiers]{Modifiers}
 
 \begin{codeblock}
 template <class Key, class Compare = less<Key>, class Container = vector<Key>>
@@ -12147,61 +12307,95 @@ class flat_multiset {
       using container_type            = Container;
 
       // \ref{flatmultiset.cons}, construct/copy/destroy
-      flat_multiset();
+      flat_multiset() : flat_multiset(key_compare()) { }
 
-      explicit flat_multiset(container_type);
+      explicit flat_multiset(container_type cont);
       template <class Alloc>
-        flat_multiset(container_type, const Alloc&);
-      flat_multiset(sorted_equivalent_t, container_type);
+        flat_multiset(container_type cont, const Alloc& a)
+          : flat_multiset(container_type(std::move(key), a)) { }
+      template <class Container>
+        explicit flat_multiset(const Container& cont)
+          : flat_multiset(cont.begin(), cont.end(), key_compare()) { }
+      template <class Container, class Alloc>
+        flat_multiset(const Container& cont, const Alloc& a)
+          : flat_multiset(cont.begin(), cont.end(), key_compare(), a) { }
+
+      flat_multiset(sorted_equivalent_t, container_type cont)
+        : c(std::move(cont)), compare(key_compare()) { }
       template <class Alloc>
-        flat_multiset(sorted_equivalent_t, container_type, const Alloc&);
-      explicit flat_multiset(const key_compare& comp);
+        flat_multiset(sorted_equivalent_t, container_type, const Alloc&)
+          : flat_multiset(s, container_type(std::move(cont), a)) { }
+      template <class Container>
+        flat_multiset(sorted_unique_t s, const Container& cont)
+          : flat_multiset(s, cont.begin(), cont.end(), key_compare()) { }
+      template <class Container, class Alloc>
+        flat_multiset(sorted_unique_t s, const Container& cont, const Alloc& a)
+          : flat_multiset(s, cont.begin(), cont.end(), key_compare(), a) { }
+
+      explicit flat_multiset(const key_compare& comp)
+        : c(container_type()), compare(comp) { }
       template <class Alloc>
         flat_multiset(const key_compare& comp, const Alloc&);
       template <class Alloc>
-        explicit flat_multiset(const Alloc&);
+        explicit flat_multiset(const Alloc& a)
+          : flat_multiset(key_compare(), a) { }
 
       template <class InputIterator>
         flat_multiset(InputIterator first, InputIterator last,
-                 const key_compare& comp = key_compare());
+                      const key_compare& comp = key_compare());
       template <class InputIterator, class Alloc>
         flat_multiset(InputIterator first, InputIterator last,
-                 const key_compare& comp, const Alloc&);
+                      const key_compare& comp, const Alloc&);
       template <class InputIterator, class Alloc>
         flat_multiset(InputIterator first, InputIterator last,
-                 const Alloc& a)
+                      const Alloc& a)
           : flat_multiset(first, last, key_compare(), a) { }
 
       template <class InputIterator>
         flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
-                 const key_compare& comp = key_compare());
+                      const key_compare& comp = key_compare())
+          : c(first, last), compare(comp) { }
       template <class InputIterator, class Alloc>
         flat_multiset(sorted_equivalent_t, InputIterator first, InputIterator last,
-                 const key_compare& comp, const Alloc&);
+                      const key_compare& comp, const Alloc&);
       template <class InputIterator, class Alloc>
-        flat_multiset(sorted_equivalent_t t, InputIterator first, InputIterator last,
-                 const Alloc& a)
-          : flat_multiset(t, first, last, key_compare(), a) { }
-      template <class Alloc>
-        flat_multiset(flat_multiset, const Alloc&);
+        flat_multiset(sorted_equivalent_t s, InputIterator first, InputIterator last,
+                      const Alloc& a)
+          : flat_multiset(s, first, last, key_compare(), a) { }
 
-      flat_multiset(initializer_list<key_type>, const key_compare& = key_compare());
       template <class Alloc>
-        flat_multiset(initializer_list<key_type>,
-                 const key_compare&, const Alloc&);
+       flat_multiset(flat_multiset&& m, const Alloc& a)
+         : c{container_type(std::move(m.c), a)}
+         , compare{std::move(m.compare)}
+       { }
+     template<class Alloc>
+       flat_multiset(const flat_multiset& m, const Alloc& a)
+         : c{container_type(m.c, a)}
+         , compare{m.compare}
+       { }
+
+      flat_multiset(initializer_list<key_type>&& il,
+                    const key_compare& comp = key_compare())
+        : flat_multiset(il, comp) { }
       template <class Alloc>
-        flat_multiset(initializer_list<key_type> il, const Alloc& a)
+        flat_multiset(initializer_list<key_type>&& il,
+                      const key_compare& comp, const Alloc& a)
+          : flat_multiset(il, comp, a) { }
+      template <class Alloc>
+        flat_multiset(initializer_list<key_type>&& il, const Alloc& a)
           : flat_multiset(il, key_compare(), a) { }
 
-      flat_multiset(sorted_equivalent_t, initializer_list<key_type>,
-               const key_compare& = key_compare());
+      flat_multiset(sorted_equivalent_t s, initializer_list<key_type>&& il,
+                    const key_compare& comp = key_compare())
+          : flat_multiset(s, il, comp) { }
       template <class Alloc>
-        flat_multiset(sorted_equivalent_t, initializer_list<key_type>,
-                 const key_compare&, const Alloc&);
+        flat_multiset(sorted_equivalent_t s, initializer_list<key_type>&& il,
+                      const key_compare& comp, const Alloc& a)
+          : flat_multiset(s, il, comp, a) { }
       template <class Alloc>
-        flat_multiset(sorted_equivalent_t t, initializer_list<key_type> il,
-                 const Alloc& a)
-          : flat_multiset(t, il, key_compare(), a) { }
+        flat_multiset(sorted_equivalent_t s, initializer_list<key_type>&& il,
+                      const Alloc& a)
+          : flat_multiset(s, il, key_compare(), a) { }
 
       flat_multiset& operator=(initializer_list<key_type>);
 
@@ -12286,6 +12480,10 @@ class flat_multiset {
         pair<iterator, iterator> equal_range(const K& x);
       template <class K>
         pair<const_iterator, const_iterator> equal_range(const K& x) const;
+
+    private:
+        container_type c;    // \expos
+        key_compare compare; // \expos
   };
 
   template <class Container>

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9984,249 +9984,249 @@ namespace std {
             class MappedContainer = vector<T>>
   class flat_map {
   public:
-      // types:
-      using key_type                  = Key;
-      using mapped_type               = T;
-      using value_type                = pair<const key_type, mapped_type>;
-      using key_compare               = Compare;
-      using reference                 = pair<const key_type&, mapped_type&>;
-      using const_reference           = pair<const key_type&, const mapped_type&>;
-      using size_type                 = size_t;
-      using difference_type           = ptrdiff_t;
-      using iterator                  = @\impdefx{type of \tcode{flat_map::iterator}}@; // see \ref{container.requirements}
-      using const_iterator            = @\impdefx{type of \tcode{flat_map::const_iterator}}@; // see \ref{container.requirements}
-      using reverse_iterator          = std::reverse_iterator<iterator>;
-      using const_reverse_iterator    = std::reverse_iterator<const_iterator>;
-      using key_container_type        = KeyContainer;
-      using mapped_container_type     = MappedContainer;
+    // types:
+    using key_type                  = Key;
+    using mapped_type               = T;
+    using value_type                = pair<const key_type, mapped_type>;
+    using key_compare               = Compare;
+    using reference                 = pair<const key_type&, mapped_type&>;
+    using const_reference           = pair<const key_type&, const mapped_type&>;
+    using size_type                 = size_t;
+    using difference_type           = ptrdiff_t;
+    using iterator                  = @\impdefx{type of \tcode{flat_map::iterator}}@; // see \ref{container.requirements}
+    using const_iterator            = @\impdefx{type of \tcode{flat_map::const_iterator}}@; // see \ref{container.requirements}
+    using reverse_iterator          = std::reverse_iterator<iterator>;
+    using const_reverse_iterator    = std::reverse_iterator<const_iterator>;
+    using key_container_type        = KeyContainer;
+    using mapped_container_type     = MappedContainer;
 
-      class value_compare {
-        friend class flat_map;
-      protected:
-        key_compare comp;
-        value_compare(key_compare c) : comp(c) { }
-      public:
-        bool operator()(const_reference x, const_reference y) const {
-          return comp(x.first, y.first);
-        }
-      };
+    class value_compare {
+      friend class flat_map;
+    protected:
+      key_compare comp;
+      value_compare(key_compare c) : comp(c) { }
+    public:
+      bool operator()(const_reference x, const_reference y) const {
+        return comp(x.first, y.first);
+      }
+    };
 
-      struct containers
-      {
-        key_container_type keys;
-        mapped_container_type values;
-      };
+    struct containers
+    {
+      key_container_type keys;
+      mapped_container_type values;
+    };
 
-      // \ref{flatmap.cons}, construct/copy/destroy
-      flat_map() : compare(key_compare()) { }
+    // \ref{flatmap.cons}, construct/copy/destroy
+    flat_map() : compare(key_compare()) { }
 
-      flat_map(key_container_type key_cont, mapped_container_type mapped_cont);
-      template <class Alloc>
-      flat_map(key_container_type key_cont, mapped_container_type mapped_cont,
+    flat_map(key_container_type key_cont, mapped_container_type mapped_cont);
+    template <class Alloc>
+    flat_map(key_container_type key_cont, mapped_container_type mapped_cont,
+             const Alloc& a)
+        : flat_map(key_container_type(std::move(key_cont), a),
+                   mapped_container_type(std::move(mapped_cont), a))
+      { }
+    template <class Container>
+      explicit flat_map(const Container& cont)
+        : flat_map(cont.begin(), cont.end(), key_compare()) { }
+    template <class Container, class Alloc>
+      flat_map(const Container& cont, const Alloc& a)
+        : flat_map(cont.begin(), cont.end(), key_compare(), a) { }
+
+    flat_map(sorted_unique_t,
+             key_container_type key_cont, mapped_container_type mapped_cont);
+    template <class Alloc>
+    flat_map(sorted_unique_t s, key_container_type key_cont,
+             mapped_container_type mapped_cont, const Alloc& a)
+        : flat_map(s, key_container_type(std::move(key_cont), a),
+                   mapped_container_type(std::move(mapped_cont), a))
+      { }
+    template <class Container>
+      flat_map(sorted_unique_t s, const Container& cont)
+        : flat_map(s, cont.begin(), cont.end(), key_compare()) { }
+    template <class Container, class Alloc>
+      flat_map(sorted_unique_t s, const Container& cont, const Alloc& a)
+        : flat_map(s, cont.begin(), cont.end(), key_compare(), a) { }
+
+    explicit flat_map(const key_compare& comp)
+      : c(containers()), compare(comp) { }
+    template <class Alloc>
+      flat_map(const key_compare& comp, const Alloc& a);
+    template <class Alloc>
+      explicit flat_map(const Alloc& a)
+        : flat_map(key_compare(), a) { }
+
+    template <class InputIterator>
+      flat_map(InputIterator first, InputIterator last,
+               const key_compare& comp = key_compare());
+    template <class InputIterator, class Alloc>
+      flat_map(InputIterator first, InputIterator last,
+               const key_compare& comp, const Alloc& a);
+    template <class InputIterator, class Alloc>
+      flat_map(InputIterator first, InputIterator last,
                const Alloc& a)
-          : flat_map(key_container_type(std::move(key_cont), a),
-                     mapped_container_type(std::move(mapped_cont), a))
-        { }
-      template <class Container>
-        explicit flat_map(const Container& cont)
-          : flat_map(cont.begin(), cont.end(), key_compare()) { }
-      template <class Container, class Alloc>
-        flat_map(const Container& cont, const Alloc& a)
-          : flat_map(cont.begin(), cont.end(), key_compare(), a) { }
+        : flat_map(first, last, key_compare(), a) { }
 
-      flat_map(sorted_unique_t,
-               key_container_type key_cont, mapped_container_type mapped_cont);
-      template <class Alloc>
-      flat_map(sorted_unique_t s, key_container_type key_cont,
-               mapped_container_type mapped_cont, const Alloc& a)
-          : flat_map(s, key_container_type(std::move(key_cont), a),
-                     mapped_container_type(std::move(mapped_cont), a))
-        { }
-      template <class Container>
-        flat_map(sorted_unique_t s, const Container& cont)
-          : flat_map(s, cont.begin(), cont.end(), key_compare()) { }
-      template <class Container, class Alloc>
-        flat_map(sorted_unique_t s, const Container& cont, const Alloc& a)
-          : flat_map(s, cont.begin(), cont.end(), key_compare(), a) { }
+    template <class InputIterator>
+      flat_map(sorted_unique_t, InputIterator first, InputIterator last,
+               const key_compare& comp = key_compare());
+    template <class InputIterator, class Alloc>
+      flat_map(sorted_unique_t, InputIterator first, InputIterator last,
+               const key_compare& comp, const Alloc& a);
+    template <class InputIterator, class Alloc>
+      flat_map(sorted_unique_t s, InputIterator first, InputIterator last,
+               const Alloc& a)
+        : flat_map(s, first, last, key_compare(), a) { }
 
-      explicit flat_map(const key_compare& comp)
-        : c(containers()), compare(comp) { }
-      template <class Alloc>
-        flat_map(const key_compare& comp, const Alloc& a);
-      template <class Alloc>
-        explicit flat_map(const Alloc& a)
-          : flat_map(key_compare(), a) { }
+    template <class Alloc>
+      flat_map(flat_map&& m, const Alloc& a)
+        : c{key_container_type(std::move(m.c.keys), a),
+            mapped_container_type(std::move(m.c.values), a)}
+        , compare{std::move(m.compare)}
+      { }
+    template<class Alloc>
+      flat_map(const flat_map& m, const Alloc& a)
+        : c{key_container_type(m.c.keys, a),
+            mapped_container_type(m.c.values, a)}
+        , compare{m.compare}
+      { }
 
-      template <class InputIterator>
-        flat_map(InputIterator first, InputIterator last,
-                 const key_compare& comp = key_compare());
-      template <class InputIterator, class Alloc>
-        flat_map(InputIterator first, InputIterator last,
-                 const key_compare& comp, const Alloc& a);
-      template <class InputIterator, class Alloc>
-        flat_map(InputIterator first, InputIterator last,
-                 const Alloc& a)
-          : flat_map(first, last, key_compare(), a) { }
-
-      template <class InputIterator>
-        flat_map(sorted_unique_t, InputIterator first, InputIterator last,
-                 const key_compare& comp = key_compare());
-      template <class InputIterator, class Alloc>
-        flat_map(sorted_unique_t, InputIterator first, InputIterator last,
-                 const key_compare& comp, const Alloc& a);
-      template <class InputIterator, class Alloc>
-        flat_map(sorted_unique_t s, InputIterator first, InputIterator last,
-                 const Alloc& a)
-          : flat_map(s, first, last, key_compare(), a) { }
-
-      template <class Alloc>
-        flat_map(flat_map&& m, const Alloc& a)
-          : c{key_container_type(std::move(m.c.keys), a),
-              mapped_container_type(std::move(m.c.values), a)}
-          , compare{std::move(m.compare)}
-        { }
-      template<class Alloc>
-        flat_map(const flat_map& m, const Alloc& a)
-          : c{key_container_type(m.c.keys, a),
-              mapped_container_type(m.c.values, a)}
-          , compare{m.compare}
-        { }
-
+    flat_map(initializer_list<value_type>&& il,
+             const key_compare& comp = key_compare())
+        : flat_map(il, comp) { }
+    template <class Alloc>
       flat_map(initializer_list<value_type>&& il,
-               const key_compare& comp = key_compare())
-          : flat_map(il, comp) { }
-      template <class Alloc>
-        flat_map(initializer_list<value_type>&& il,
-                 const key_compare& comp, const Alloc& a)
-          : flat_map(il, comp, a) { }
-      template <class Alloc>
-        flat_map(initializer_list<value_type>&& il, const Alloc& a)
-          : flat_map(il, key_compare(), a) { }
+               const key_compare& comp, const Alloc& a)
+        : flat_map(il, comp, a) { }
+    template <class Alloc>
+      flat_map(initializer_list<value_type>&& il, const Alloc& a)
+        : flat_map(il, key_compare(), a) { }
 
+    flat_map(sorted_unique_t s, initializer_list<value_type>&& il,
+             const key_compare& comp = key_compare())
+        : flat_map(s, il, comp) { }
+    template <class Alloc>
       flat_map(sorted_unique_t s, initializer_list<value_type>&& il,
-               const key_compare& comp = key_compare())
-          : flat_map(s ,il, comp) { }
-      template <class Alloc>
-        flat_map(sorted_unique_t s, initializer_list<value_type>&& il,
-                 const key_compare& comp, const Alloc& a)
-          : flat_map(s, il, comp, a) { }
-      template <class Alloc>
-        flat_map(sorted_unique_t s, initializer_list<value_type>&& il,
-                 const Alloc& a)
-          : flat_map(s, il, key_compare(), a) { }
+               const key_compare& comp, const Alloc& a)
+        : flat_map(s, il, comp, a) { }
+    template <class Alloc>
+      flat_map(sorted_unique_t s, initializer_list<value_type>&& il,
+               const Alloc& a)
+        : flat_map(s, il, key_compare(), a) { }
 
-      flat_map& operator=(initializer_list<value_type> il);
+    flat_map& operator=(initializer_list<value_type> il);
 
-      // iterators
-      iterator                begin() noexcept;
-      const_iterator          begin() const noexcept;
-      iterator                end() noexcept;
-      const_iterator          end() const noexcept;
+    // iterators
+    iterator                begin() noexcept;
+    const_iterator          begin() const noexcept;
+    iterator                end() noexcept;
+    const_iterator          end() const noexcept;
 
-      reverse_iterator        rbegin() noexcept;
-      const_reverse_iterator  rbegin() const noexcept;
-      reverse_iterator        rend() noexcept;
-      const_reverse_iterator  rend() const noexcept;
+    reverse_iterator        rbegin() noexcept;
+    const_reverse_iterator  rbegin() const noexcept;
+    reverse_iterator        rend() noexcept;
+    const_reverse_iterator  rend() const noexcept;
 
-      const_iterator          cbegin() const noexcept;
-      const_iterator          cend() const noexcept;
-      const_reverse_iterator  crbegin() const noexcept;
-      const_reverse_iterator  crend() const noexcept;
+    const_iterator          cbegin() const noexcept;
+    const_iterator          cend() const noexcept;
+    const_reverse_iterator  crbegin() const noexcept;
+    const_reverse_iterator  crend() const noexcept;
 
-      // \ref{flatmap.capacity}, capacity
-      [[nodiscard]] bool empty() const noexcept;
-      size_type size() const noexcept;
-      size_type max_size() const noexcept;
+    // \ref{flatmap.capacity}, capacity
+    [[nodiscard]] bool empty() const noexcept;
+    size_type size() const noexcept;
+    size_type max_size() const noexcept;
 
-      // \ref{flatmap.access}, element access
-      mapped_type& operator[](const key_type& x);
-      mapped_type& operator[](key_type&& x);
-      mapped_type& at(const key_type& x);
-      const mapped_type& at(const key_type& x) const;
+    // \ref{flatmap.access}, element access
+    mapped_type& operator[](const key_type& x);
+    mapped_type& operator[](key_type&& x);
+    mapped_type& at(const key_type& x);
+    const mapped_type& at(const key_type& x) const;
 
-      // \ref{flatmap.modifiers}, modifiers
-      template <class... Args> pair<iterator, bool> emplace(Args&&... args);
-      template <class... Args>
-        iterator emplace_hint(const_iterator position, Args&&... args);
-      pair<iterator, bool> insert(const value_type& x);
-      pair<iterator, bool> insert(value_type&& x);
-      template <class P> pair<iterator, bool> insert(P&& x);
-      iterator insert(const_iterator position, const value_type& x);
-      iterator insert(const_iterator position, value_type&& x);
-      template <class P>
-        iterator insert(const_iterator position, P&&);
-      template <class InputIterator>
-        void insert(InputIterator first, InputIterator last);
-      template <class InputIterator>
-        void insert(sorted_unique_t, InputIterator first, InputIterator last);
-      void insert(initializer_list<value_type>);
-      void insert(sorted_unique_t, initializer_list<value_type> il);
+    // \ref{flatmap.modifiers}, modifiers
+    template <class... Args> pair<iterator, bool> emplace(Args&&... args);
+    template <class... Args>
+      iterator emplace_hint(const_iterator position, Args&&... args);
+    pair<iterator, bool> insert(const value_type& x);
+    pair<iterator, bool> insert(value_type&& x);
+    template <class P> pair<iterator, bool> insert(P&& x);
+    iterator insert(const_iterator position, const value_type& x);
+    iterator insert(const_iterator position, value_type&& x);
+    template <class P>
+      iterator insert(const_iterator position, P&&);
+    template <class InputIterator>
+      void insert(InputIterator first, InputIterator last);
+    template <class InputIterator>
+      void insert(sorted_unique_t, InputIterator first, InputIterator last);
+    void insert(initializer_list<value_type>);
+    void insert(sorted_unique_t, initializer_list<value_type> il);
 
-      containers extract() &&;
-      void replace(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
+    containers extract() &&;
+    void replace(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
 
-      template <class... Args>
-        pair<iterator, bool> try_emplace(const key_type& k, Args&&... args);
-      template <class... Args>
-        pair<iterator, bool> try_emplace(key_type&& k, Args&&... args);
-      template <class... Args>
-        iterator try_emplace(const_iterator hint, const key_type& k,
-                             Args&&... args);
-      template <class... Args>
-        iterator try_emplace(const_iterator hint, key_type&& k, Args&&... args);
-      template <class M>
-        pair<iterator, bool> insert_or_assign(const key_type& k, M&& obj);
-      template <class M>
-        pair<iterator, bool> insert_or_assign(key_type&& k, M&& obj);
-      template <class M>
-        iterator insert_or_assign(const_iterator hint, const key_type& k,
-                                  M&& obj);
-      template <class M>
-        iterator insert_or_assign(const_iterator hint, key_type&& k, M&& obj);
+    template <class... Args>
+      pair<iterator, bool> try_emplace(const key_type& k, Args&&... args);
+    template <class... Args>
+      pair<iterator, bool> try_emplace(key_type&& k, Args&&... args);
+    template <class... Args>
+      iterator try_emplace(const_iterator hint, const key_type& k,
+                           Args&&... args);
+    template <class... Args>
+      iterator try_emplace(const_iterator hint, key_type&& k, Args&&... args);
+    template <class M>
+      pair<iterator, bool> insert_or_assign(const key_type& k, M&& obj);
+    template <class M>
+      pair<iterator, bool> insert_or_assign(key_type&& k, M&& obj);
+    template <class M>
+      iterator insert_or_assign(const_iterator hint, const key_type& k,
+                                M&& obj);
+    template <class M>
+      iterator insert_or_assign(const_iterator hint, key_type&& k, M&& obj);
 
-      iterator erase(iterator position);
-      iterator erase(const_iterator position);
-      size_type erase(const key_type& x);
-      iterator erase(const_iterator first, const_iterator last);
+    iterator erase(iterator position);
+    iterator erase(const_iterator position);
+    size_type erase(const key_type& x);
+    iterator erase(const_iterator first, const_iterator last);
 
-      void swap(flat_map& fm) noexcept;
-      void clear() noexcept;
+    void swap(flat_map& fm) noexcept;
+    void clear() noexcept;
 
-      // observers
-      key_compare key_comp() const;
-      value_compare value_comp() const;
+    // observers
+    key_compare key_comp() const;
+    value_compare value_comp() const;
 
-      const key_container_type& keys() const      { return c.keys; }
-      const mapped_container_type& values() const { return c.values; }
+    const key_container_type& keys() const      { return c.keys; }
+    const mapped_container_type& values() const { return c.values; }
 
-      // map operations
-      iterator find(const key_type& x);
-      const_iterator find(const key_type& x) const;
-      template <class K> iterator find(const K& x);
-      template <class K> const_iterator find(const K& x) const;
+    // map operations
+    iterator find(const key_type& x);
+    const_iterator find(const key_type& x) const;
+    template <class K> iterator find(const K& x);
+    template <class K> const_iterator find(const K& x) const;
 
-      size_type count(const key_type& x) const;
-      template <class K> size_type count(const K& x) const;
+    size_type count(const key_type& x) const;
+    template <class K> size_type count(const K& x) const;
 
-      bool contains(const key_type& x) const;
-      template <class K> bool contains(const K& x) const;
+    bool contains(const key_type& x) const;
+    template <class K> bool contains(const K& x) const;
 
-      iterator lower_bound(const key_type& x);
-      const_iterator lower_bound(const key_type& x) const;
-      template <class K> iterator lower_bound(const K& x);
-      template <class K> const_iterator lower_bound(const K& x) const;
+    iterator lower_bound(const key_type& x);
+    const_iterator lower_bound(const key_type& x) const;
+    template <class K> iterator lower_bound(const K& x);
+    template <class K> const_iterator lower_bound(const K& x) const;
 
-      iterator upper_bound(const key_type& x);
-      const_iterator upper_bound(const key_type& x) const;
-      template <class K> iterator upper_bound(const K& x);
-      template <class K> const_iterator upper_bound(const K& x) const;
+    iterator upper_bound(const key_type& x);
+    const_iterator upper_bound(const key_type& x) const;
+    template <class K> iterator upper_bound(const K& x);
+    template <class K> const_iterator upper_bound(const K& x) const;
 
-      pair<iterator, iterator> equal_range(const key_type& x);
-      pair<const_iterator, const_iterator> equal_range(const key_type& x) const;
-      template <class K>
-        pair<iterator, iterator> equal_range(const K& x);
-      template <class K>
-        pair<const_iterator, const_iterator> equal_range(const K& x) const;
+    pair<iterator, iterator> equal_range(const key_type& x);
+    pair<const_iterator, const_iterator> equal_range(const key_type& x) const;
+    template <class K>
+      pair<iterator, iterator> equal_range(const K& x);
+    template <class K>
+      pair<const_iterator, const_iterator> equal_range(const K& x) const;
 
   private:
     containers c;        // \expos
@@ -11066,223 +11066,223 @@ namespace std {
             class MappedContainer = vector<T>>
   class flat_multimap {
   public:
-      // types:
-      using key_type                  = Key;
-      using mapped_type               = T;
-      using value_type                = pair<const key_type, mapped_type>;
-      using key_compare               = Compare;
-      using reference                 = pair<const key_type&, mapped_type&>;
-      using const_reference           = pair<const key_type&, const mapped_type&>;
-      using size_type                 = size_t;
-      using difference_type           = ptrdiff_t;
-      using iterator                  = @\impdefx{type of \tcode{flat_multimap::iterator}}@; // see \ref{container.requirements}
-      using const_iterator            = @\impdefx{type of \tcode{flat_multimap::const_iterator}}@; // see \ref{container.requirements}
-      using reverse_iterator          = std::reverse_iterator<iterator>;
-      using const_reverse_iterator    = std::reverse_iterator<const_iterator>;
-      using key_container_type        = KeyContainer;
-      using mapped_container_type     = MappedContainer;
+    // types:
+    using key_type                  = Key;
+    using mapped_type               = T;
+    using value_type                = pair<const key_type, mapped_type>;
+    using key_compare               = Compare;
+    using reference                 = pair<const key_type&, mapped_type&>;
+    using const_reference           = pair<const key_type&, const mapped_type&>;
+    using size_type                 = size_t;
+    using difference_type           = ptrdiff_t;
+    using iterator                  = @\impdefx{type of \tcode{flat_multimap::iterator}}@; // see \ref{container.requirements}
+    using const_iterator            = @\impdefx{type of \tcode{flat_multimap::const_iterator}}@; // see \ref{container.requirements}
+    using reverse_iterator          = std::reverse_iterator<iterator>;
+    using const_reverse_iterator    = std::reverse_iterator<const_iterator>;
+    using key_container_type        = KeyContainer;
+    using mapped_container_type     = MappedContainer;
 
-      class value_compare {
-        friend class flat_multimap;
-      protected:
-        key_compare comp;
-        value_compare(key_compare c) : comp(c) { }
-      public:
-        bool operator()(const_reference x, const_reference y) const {
-          return comp(x.first, y.first);
-        }
-      };
+    class value_compare {
+      friend class flat_multimap;
+    protected:
+      key_compare comp;
+      value_compare(key_compare c) : comp(c) { }
+    public:
+      bool operator()(const_reference x, const_reference y) const {
+        return comp(x.first, y.first);
+      }
+    };
 
-      struct containers
-      {
-        key_container_type keys;
-        mapped_container_type values;
-      };
+    struct containers
+    {
+      key_container_type keys;
+      mapped_container_type values;
+    };
 
-      // \ref{flatmultimap.cons}, construct/copy/destroy
-      flat_multimap() : compare(key_compare()) { }
+    // \ref{flatmultimap.cons}, construct/copy/destroy
+    flat_multimap() : compare(key_compare()) { }
 
-      flat_multimap(key_container_type key_cont, mapped_container_type mapped_cont);
-      template <class Alloc>
-      flat_multimap(key_container_type key_cont, mapped_container_type mapped_cont,
+    flat_multimap(key_container_type key_cont, mapped_container_type mapped_cont);
+    template <class Alloc>
+    flat_multimap(key_container_type key_cont, mapped_container_type mapped_cont,
+                  const Alloc& a)
+        : flat_multimap(key_container_type(std::move(key_cont), a),
+                        mapped_container_type(std::move(mapped_cont), a))
+      { }
+    template <class Container>
+      explicit flat_multimap(const Container& cont)
+        : flat_multimap(cont.begin(), cont.end(), key_compare()) { }
+    template <class Container, class Alloc>
+      flat_multimap(const Container& cont, const Alloc& a)
+        : flat_multimap(cont.begin(), cont.end(), key_compare(), a) { }
+
+    flat_multimap(sorted_equivalent_t,
+                  key_container_type key_cont, mapped_container_type mapped_cont);
+    template <class Alloc>
+    flat_multimap(sorted_equivalent_t, key_container_type key_cont,
+                  mapped_container_type mapped_cont, const Alloc& a)
+        : flat_multimap(key_container_type(std::move(key_cont), a),
+                        mapped_container_type(std::move(mapped_cont), a))
+      { }
+    template <class Container>
+      flat_multimap(sorted_equivalent_t s, const Container& cont)
+        : flat_multimap(s, cont.begin(), cont.end(), key_compare()) { }
+    template <class Container, class Alloc>
+      flat_multimap(sorted_equivalent_t s, const Container& cont, const Alloc& a)
+        : flat_multimap(s, cont.begin(), cont.end(), key_compare(), a) { }
+
+    explicit flat_multimap(const key_compare& comp)
+      : c(containers()), compare(comp) { }
+    template <class Alloc>
+      flat_multimap(const key_compare& comp, const Alloc& a);
+    template <class Alloc>
+      explicit flat_multimap(const Alloc& a)
+        : flat_multimap(key_compare(), a) { }
+
+    template <class InputIterator>
+      flat_multimap(InputIterator first, InputIterator last,
+                    const key_compare& comp = key_compare());
+    template <class InputIterator, class Alloc>
+      flat_multimap(InputIterator first, InputIterator last,
+                   const key_compare& comp, const Alloc& a);
+    template <class InputIterator, class Alloc>
+      flat_multimap(InputIterator first, InputIterator last,
                     const Alloc& a)
-          : flat_multimap(key_container_type(std::move(key_cont), a),
-                          mapped_container_type(std::move(mapped_cont), a))
-        { }
-      template <class Container>
-        explicit flat_multimap(const Container& cont)
-          : flat_multimap(cont.begin(), cont.end(), key_compare()) { }
-      template <class Container, class Alloc>
-        flat_multimap(const Container& cont, const Alloc& a)
-          : flat_multimap(cont.begin(), cont.end(), key_compare(), a) { }
+        : flat_multimap(first, last, key_compare(), a) { }
 
-      flat_multimap(sorted_equivalent_t,
-                    key_container_type key_cont, mapped_container_type mapped_cont);
-      template <class Alloc>
-      flat_multimap(sorted_equivalent_t, key_container_type key_cont,
-                    mapped_container_type mapped_cont, const Alloc& a)
-          : flat_multimap(key_container_type(std::move(key_cont), a),
-                          mapped_container_type(std::move(mapped_cont), a))
-        { }
-      template <class Container>
-        flat_multimap(sorted_equivalent_t s, const Container& cont)
-          : flat_multimap(s, cont.begin(), cont.end(), key_compare()) { }
-      template <class Container, class Alloc>
-        flat_multimap(sorted_equivalent_t s, const Container& cont, const Alloc& a)
-          : flat_multimap(s, cont.begin(), cont.end(), key_compare(), a) { }
+    template <class InputIterator>
+      flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
+                    const key_compare& comp = key_compare());
+    template <class InputIterator, class Alloc>
+      flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
+                    const key_compare& comp, const Alloc& a);
+    template <class InputIterator, class Alloc>
+      flat_multimap(sorted_equivalent_t s, InputIterator first, InputIterator last,
+                    const Alloc& a)
+        : flat_multimap(s, first, last, key_compare(), a) { }
 
-      explicit flat_multimap(const key_compare& comp)
-        : c(containers()), compare(comp) { }
-      template <class Alloc>
-        flat_multimap(const key_compare& comp, const Alloc& a);
-      template <class Alloc>
-        explicit flat_multimap(const Alloc& a)
-          : flat_multimap(key_compare(), a) { }
+    template <class Alloc>
+      flat_multimap(flat_multimap&& m, const Alloc& a)
+        : c{key_container_type(std::move(m.c.keys), a),
+            mapped_container_type(std::move(m.c.values), a)}
+        , compare{std::move(m.compare)}
+      { }
+    template<class Alloc>
+      flat_multimap(const flat_multimap& m, const Alloc& a)
+        : c{key_container_type(m.c.keys, a), mapped_container_type(m.c.values, a)}
+        , compare{m.compare}
+      { }
 
-      template <class InputIterator>
-        flat_multimap(InputIterator first, InputIterator last,
-                      const key_compare& comp = key_compare());
-      template <class InputIterator, class Alloc>
-        flat_multimap(InputIterator first, InputIterator last,
-                     const key_compare& comp, const Alloc& a);
-      template <class InputIterator, class Alloc>
-        flat_multimap(InputIterator first, InputIterator last,
-                      const Alloc& a)
-          : flat_multimap(first, last, key_compare(), a) { }
-
-      template <class InputIterator>
-        flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
-                      const key_compare& comp = key_compare());
-      template <class InputIterator, class Alloc>
-        flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
-                      const key_compare& comp, const Alloc& a);
-      template <class InputIterator, class Alloc>
-        flat_multimap(sorted_equivalent_t s, InputIterator first, InputIterator last,
-                      const Alloc& a)
-          : flat_multimap(s, first, last, key_compare(), a) { }
-
-      template <class Alloc>
-        flat_multimap(flat_multimap&& m, const Alloc& a)
-          : c{key_container_type(std::move(m.c.keys), a),
-              mapped_container_type(std::move(m.c.values), a)}
-          , compare{std::move(m.compare)}
-        { }
-      template<class Alloc>
-        flat_multimap(const flat_multimap& m, const Alloc& a)
-          : c{key_container_type(m.c.keys, a), mapped_container_type(m.c.values, a)}
-          , compare{m.compare}
-        { }
-
+    flat_multimap(initializer_list<value_type>&& il,
+                  const key_compare& comp = key_compare())
+        : flat_multimap(il, comp) { }
+    template <class Alloc>
       flat_multimap(initializer_list<value_type>&& il,
-                    const key_compare& comp = key_compare())
-          : flat_multimap(il, comp) { }
-      template <class Alloc>
-        flat_multimap(initializer_list<value_type>&& il,
-                      const key_compare& comp, const Alloc& a)
-          : flat_multimap(il, comp, a) { }
-      template <class Alloc>
-        flat_multimap(initializer_list<value_type>&& il, const Alloc& a)
-          : flat_multimap(il, key_compare(), a) { }
+                    const key_compare& comp, const Alloc& a)
+        : flat_multimap(il, comp, a) { }
+    template <class Alloc>
+      flat_multimap(initializer_list<value_type>&& il, const Alloc& a)
+        : flat_multimap(il, key_compare(), a) { }
 
+    flat_multimap(sorted_equivalent_t s, initializer_list<value_type>&& il,
+                  const key_compare& comp = key_compare())
+        : flat_multimap(s, il, comp) { }
+    template <class Alloc>
       flat_multimap(sorted_equivalent_t s, initializer_list<value_type>&& il,
-                    const key_compare& comp = key_compare())
-          : flat_multimap(s, il, comp) { }
-      template <class Alloc>
-        flat_multimap(sorted_equivalent_t s, initializer_list<value_type>&& il,
-                      const key_compare& comp, const Alloc& a)
-          : flat_multimap(s, il, comp, a) { }
-      template <class Alloc>
-        flat_multimap(sorted_equivalent_t s, initializer_list<value_type>&& il,
-                      const Alloc& a)
-          : flat_multimap(s, il, key_compare(), a) { }
+                    const key_compare& comp, const Alloc& a)
+        : flat_multimap(s, il, comp, a) { }
+    template <class Alloc>
+      flat_multimap(sorted_equivalent_t s, initializer_list<value_type>&& il,
+                    const Alloc& a)
+        : flat_multimap(s, il, key_compare(), a) { }
 
-      flat_multimap& operator=(initializer_list<value_type> il);
+    flat_multimap& operator=(initializer_list<value_type> il);
 
-      // iterators
-      iterator                begin() noexcept;
-      const_iterator          begin() const noexcept;
-      iterator                end() noexcept;
-      const_iterator          end() const noexcept;
+    // iterators
+    iterator                begin() noexcept;
+    const_iterator          begin() const noexcept;
+    iterator                end() noexcept;
+    const_iterator          end() const noexcept;
 
-      reverse_iterator        rbegin() noexcept;
-      const_reverse_iterator  rbegin() const noexcept;
-      reverse_iterator        rend() noexcept;
-      const_reverse_iterator  rend() const noexcept;
+    reverse_iterator        rbegin() noexcept;
+    const_reverse_iterator  rbegin() const noexcept;
+    reverse_iterator        rend() noexcept;
+    const_reverse_iterator  rend() const noexcept;
 
-      const_iterator          cbegin() const noexcept;
-      const_iterator          cend() const noexcept;
-      const_reverse_iterator  crbegin() const noexcept;
-      const_reverse_iterator  crend() const noexcept;
+    const_iterator          cbegin() const noexcept;
+    const_iterator          cend() const noexcept;
+    const_reverse_iterator  crbegin() const noexcept;
+    const_reverse_iterator  crend() const noexcept;
 
-      // capacity
-      [[nodiscard]] bool empty() const noexcept;
-      size_type size() const noexcept;
-      size_type max_size() const noexcept;
+    // capacity
+    [[nodiscard]] bool empty() const noexcept;
+    size_type size() const noexcept;
+    size_type max_size() const noexcept;
 
-      // \ref{flatmultimap.modifiers}, modifiers
-      template <class... Args> pair<iterator, bool> emplace(Args&&... args);
-      template <class... Args>
-        iterator emplace_hint(const_iterator position, Args&&... args);
-      pair<iterator, bool> insert(const value_type& x);
-      pair<iterator, bool> insert(value_type&& x);
-      template <class P> pair<iterator, bool> insert(P&& x);
-      iterator insert(const_iterator position, const value_type& x);
-      iterator insert(const_iterator position, value_type&& x);
-      template <class P>
-        iterator insert(const_iterator position, P&&);
-      template <class InputIterator>
-        void insert(InputIterator first, InputIterator last);
-      template <class InputIterator>
-        void insert(sorted_equivalent_t, InputIterator first, InputIterator last);
-      void insert(initializer_list<value_type>);
-      void insert(sorted_equivalent_t, initializer_list<value_type> il);
+    // \ref{flatmultimap.modifiers}, modifiers
+    template <class... Args> pair<iterator, bool> emplace(Args&&... args);
+    template <class... Args>
+      iterator emplace_hint(const_iterator position, Args&&... args);
+    pair<iterator, bool> insert(const value_type& x);
+    pair<iterator, bool> insert(value_type&& x);
+    template <class P> pair<iterator, bool> insert(P&& x);
+    iterator insert(const_iterator position, const value_type& x);
+    iterator insert(const_iterator position, value_type&& x);
+    template <class P>
+      iterator insert(const_iterator position, P&&);
+    template <class InputIterator>
+      void insert(InputIterator first, InputIterator last);
+    template <class InputIterator>
+      void insert(sorted_equivalent_t, InputIterator first, InputIterator last);
+    void insert(initializer_list<value_type>);
+    void insert(sorted_equivalent_t, initializer_list<value_type> il);
 
-      containers extract() &&;
-      void replace(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
+    containers extract() &&;
+    void replace(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
 
-      iterator erase(iterator position);
-      iterator erase(const_iterator position);
-      size_type erase(const key_type& x);
-      iterator erase(const_iterator first, const_iterator last);
+    iterator erase(iterator position);
+    iterator erase(const_iterator position);
+    size_type erase(const key_type& x);
+    iterator erase(const_iterator first, const_iterator last);
 
-      void swap(flat_multimap& fm) noexcept;
-      void clear() noexcept;
+    void swap(flat_multimap& fm) noexcept;
+    void clear() noexcept;
 
-      // observers
-      key_compare key_comp() const;
-      value_compare value_comp() const;
+    // observers
+    key_compare key_comp() const;
+    value_compare value_comp() const;
 
-      const key_container_type& keys() const      { return c.keys; }
-      const mapped_container_type& values() const { return c.values; }
+    const key_container_type& keys() const      { return c.keys; }
+    const mapped_container_type& values() const { return c.values; }
 
-      // map operations
-      iterator find(const key_type& x);
-      const_iterator find(const key_type& x) const;
-      template <class K> iterator find(const K& x);
-      template <class K> const_iterator find(const K& x) const;
+    // map operations
+    iterator find(const key_type& x);
+    const_iterator find(const key_type& x) const;
+    template <class K> iterator find(const K& x);
+    template <class K> const_iterator find(const K& x) const;
 
-      size_type count(const key_type& x) const;
-      template <class K> size_type count(const K& x) const;
+    size_type count(const key_type& x) const;
+    template <class K> size_type count(const K& x) const;
 
-      bool contains(const key_type& x) const;
-      template <class K> bool contains(const K& x) const;
+    bool contains(const key_type& x) const;
+    template <class K> bool contains(const K& x) const;
 
-      iterator lower_bound(const key_type& x);
-      const_iterator lower_bound(const key_type& x) const;
-      template <class K> iterator lower_bound(const K& x);
-      template <class K> const_iterator lower_bound(const K& x) const;
+    iterator lower_bound(const key_type& x);
+    const_iterator lower_bound(const key_type& x) const;
+    template <class K> iterator lower_bound(const K& x);
+    template <class K> const_iterator lower_bound(const K& x) const;
 
-      iterator upper_bound(const key_type& x);
-      const_iterator upper_bound(const key_type& x) const;
-      template <class K> iterator upper_bound(const K& x);
-      template <class K> const_iterator upper_bound(const K& x) const;
+    iterator upper_bound(const key_type& x);
+    const_iterator upper_bound(const key_type& x) const;
+    template <class K> iterator upper_bound(const K& x);
+    template <class K> const_iterator upper_bound(const K& x) const;
 
-      pair<iterator, iterator> equal_range(const key_type& x);
-      pair<const_iterator, const_iterator> equal_range(const key_type& x) const;
-      template <class K>
-        pair<iterator, iterator> equal_range(const K& x);
-      template <class K>
-        pair<const_iterator, const_iterator> equal_range(const K& x) const;
+    pair<iterator, iterator> equal_range(const key_type& x);
+    pair<const_iterator, const_iterator> equal_range(const key_type& x) const;
+    template <class K>
+      pair<iterator, iterator> equal_range(const K& x);
+    template <class K>
+      pair<const_iterator, const_iterator> equal_range(const K& x) const;
 
   private:
     containers c;        // \expos

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9952,10 +9952,10 @@ namespace std {
       // types:
       using key_type                  = Key;
       using mapped_type               = T;
-      using value_type                = pair<const Key, T>;
+      using value_type                = pair<const key_type, mapped_type>;
       using key_compare               = Compare;
-      using reference                 = pair<const Key&, T&>;
-      using const_reference           = pair<const Key&, const T&>;
+      using reference                 = pair<const key_type&, mapped_type&>;
+      using const_reference           = pair<const key_type&, const mapped_type&>;
       using size_type                 = size_t;
       using difference_type           = ptrdiff_t;
       using iterator                  = @\impdefx{type of \tcode{flat_map::iterator}}@; // see \ref{container.requirements}
@@ -9968,8 +9968,8 @@ namespace std {
       class value_compare {
         friend class flat_map;
       protected:
-        Compare comp;
-        value_compare(Compare c) : comp(c) { }
+        key_compare comp;
+        value_compare(key_compare c) : comp(c) { }
       public:
         bool operator()(const value_type& x, const value_type& y) const {
           return comp(x.first, y.first);
@@ -9978,58 +9978,58 @@ namespace std {
 
       struct containers
       {
-        KeyContainer keys;
-        MappedContainer values;
+        key_container_type keys;
+        mapped_container_type values;
       };
 
       // \ref{flatmap.cons}, construct/copy/destroy
       flat_map();
 
-      flat_map(KeyContainer&& key_cont, MappedContainer&& mapped_cont);
+      flat_map(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
       template <class Container>
         explicit flat_map(const Container& cont)
-          : flat_map(cont.begin(), cont.end(), Compare()) { }
+          : flat_map(cont.begin(), cont.end(), key_compare()) { }
       template <class Container, class Alloc>
         flat_map(const Container& cont, const Alloc& a)
-          : flat_map(cont.begin(), cont.end(), Compare(), a) { }
+          : flat_map(cont.begin(), cont.end(), key_compare(), a) { }
 
       flat_map(sorted_unique_t,
-               KeyContainer&& key_cont, MappedContainer&& mapped_cont);
+               key_container_type&& key_cont, mapped_container_type&& mapped_cont);
       template <class Container>
         flat_map(sorted_unique_t s, const Container& cont)
-          : flat_map(s, cont.begin(), cont.end(), Compare()) { }
+          : flat_map(s, cont.begin(), cont.end(), key_compare()) { }
       template <class Container, class Alloc>
         flat_map(sorted_unique_t s, const Container& cont, const Alloc& a)
-          : flat_map(s, cont.begin(), cont.end(), Compare(), a) { }
+          : flat_map(s, cont.begin(), cont.end(), key_compare(), a) { }
 
-      explicit flat_map(const Compare& comp);
+      explicit flat_map(const key_compare& comp);
       template <class Alloc>
-        flat_map(const Compare& comp, const Alloc& a);
+        flat_map(const key_compare& comp, const Alloc& a);
       template <class Alloc>
         explicit flat_map(const Alloc& a)
-          : flat_map(Compare(), a) { }
+          : flat_map(key_compare(), a) { }
 
       template <class InputIterator>
         flat_map(InputIterator first, InputIterator last,
-                 const Compare& comp = Compare());
+                 const key_compare& comp = key_compare());
       template <class InputIterator, class Alloc>
         flat_map(InputIterator first, InputIterator last,
-                 const Compare& comp, const Alloc& a);
+                 const key_compare& comp, const Alloc& a);
       template <class InputIterator, class Alloc>
         flat_map(InputIterator first, InputIterator last,
                  const Alloc& a)
-          : flat_map(first, last, Compare(), a) { }
+          : flat_map(first, last, key_compare(), a) { }
 
       template <class InputIterator>
         flat_map(sorted_unique_t, InputIterator first, InputIterator last,
-                 const Compare& comp = Compare());
+                 const key_compare& comp = key_compare());
       template <class InputIterator, class Alloc>
         flat_map(sorted_unique_t, InputIterator first, InputIterator last,
-                 const Compare& comp, const Alloc& a);
+                 const key_compare& comp, const Alloc& a);
       template <class InputIterator, class Alloc>
         flat_map(sorted_unique_t s, InputIterator first, InputIterator last,
                  const Alloc& a)
-          : flat_map(s, first, last, Compare(), a) { }
+          : flat_map(s, first, last, key_compare(), a) { }
 
       template <class Alloc>
         flat_map(const flat_map& m, const Alloc& a)
@@ -10042,30 +10042,30 @@ namespace std {
           , c{{m.c.keys, a}, {m.c.values, a}}
         {}
 
-      flat_map(initializer_list<pair<Key, T>>&& il,
-               const Compare& comp = Compare())
+      flat_map(initializer_list<pair<key_type, mapped_type>>&& il,
+               const key_compare& comp = key_compare())
           : flat_map(il, comp) { }
       template <class Alloc>
-        flat_map(initializer_list<pair<Key, T>>&& il,
-                 const Compare& comp, const Alloc& a)
+        flat_map(initializer_list<pair<key_type, mapped_type>>&& il,
+                 const key_compare& comp, const Alloc& a)
           : flat_map(il, comp, a) { }
       template <class Alloc>
-        flat_map(initializer_list<pair<Key, T>>&& il, const Alloc& a)
-          : flat_map(il, Compare(), a) { }
+        flat_map(initializer_list<pair<key_type, mapped_type>>&& il, const Alloc& a)
+          : flat_map(il, key_compare(), a) { }
 
-      flat_map(sorted_unique_t s, initializer_list<pair<Key, T>>&& il,
-               const Compare& comp = Compare())
+      flat_map(sorted_unique_t s, initializer_list<pair<key_type, mapped_type>>&& il,
+               const key_compare& comp = key_compare())
           : flat_map(s ,il, comp) { }
       template <class Alloc>
-        flat_map(sorted_unique_t s, initializer_list<pair<Key, T>>&& il,
-                 const Compare& comp, const Alloc& a)
+        flat_map(sorted_unique_t s, initializer_list<pair<key_type, mapped_type>>&& il,
+                 const key_compare& comp, const Alloc& a)
           : flat_map(s, il, comp, a) { }
       template <class Alloc>
-        flat_map(sorted_unique_t s, initializer_list<pair<Key, T>>&& il,
+        flat_map(sorted_unique_t s, initializer_list<pair<key_type, mapped_type>>&& il,
                  const Alloc& a)
-          : flat_map(s, il, Compare(), a) { }
+          : flat_map(s, il, key_compare(), a) { }
 
-      flat_map& operator=(initializer_list<pair<Key, T>> il);
+      flat_map& operator=(initializer_list<pair<key_type, mapped_type>> il);
 
       // iterators
       iterator                begin() noexcept;
@@ -10109,11 +10109,11 @@ namespace std {
         void insert(InputIterator first, InputIterator last);
       template <class InputIterator>
         void insert(sorted_unique_t, InputIterator first, InputIterator last);
-      void insert(initializer_list<pair<Key, T>>);
-      void insert(sorted_unique_t, initializer_list<pair<Key, T>> il);
+      void insert(initializer_list<pair<key_type, mapped_type>>);
+      void insert(sorted_unique_t, initializer_list<pair<key_type, mapped_type>> il);
 
       containers extract() &&;
-      void replace(KeyContainer&& key_cont, MappedContainer&& mapped_cont);
+      void replace(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
 
       template <class... Args>
         pair<iterator, bool> try_emplace(const key_type& k, Args&&... args);
@@ -10141,21 +10141,21 @@ namespace std {
 
       void swap(flat_map& fm)
         noexcept(
-          noexcept(declval<KeyContainer>().swap(declval<KeyContainer&>())) &&
-          noexcept(declval<MappedContainer>().swap(declval<MappedContainer&>()))
+          noexcept(declval<key_container_type>().swap(declval<key_container_type&>())) &&
+          noexcept(declval<mapped_container_type>().swap(declval<mapped_container_type&>()))
         );
       void clear() noexcept;
 
       template<class C2>
-        void merge(flat_map<Key, T, C2, KeyContainer, MappedContainer>& source);
+        void merge(flat_map<key_type, mapped_type, C2, key_container_type, mapped_container_type>& source);
       template<class C2>
-        void merge(flat_map<Key, T, C2, KeyContainer, MappedContainer>&& source);
-      template<class C2>
-        void merge(
-          flat_map<Key, T, C2, KeyContainer, MappedContainer>& source);
+        void merge(flat_map<key_type, mapped_type, C2, key_container_type, mapped_container_type>&& source);
       template<class C2>
         void merge(
-          flat_map<Key, T, C2, KeyContainer, MappedContainer>&& source);
+          flat_map<key_type, mapped_type, C2, key_container_type, mapped_container_type>& source);
+      template<class C2>
+        void merge(
+          flat_map<key_type, mapped_type, C2, key_container_type, mapped_container_type>&& source);
 
       // observers
       key_compare key_comp() const;
@@ -10191,8 +10191,8 @@ namespace std {
         pair<const_iterator, const_iterator> equal_range(const K& x) const;
 
   private:
-    containers c;    // \expos
-    Compare compare; // \expos
+    containers c;        // \expos
+    key_compare compare; // \expos
   };
 
   template<class Container>
@@ -10372,8 +10372,8 @@ namespace std {
 \rSec3[flatmap.cons]{Constructors}
 
 \pnum
-The effect of calling a constructor that takes both \tcode{KeyContainer}
-and \tcode{MappedContainer} arguments with containers of different sizes is
+The effect of calling a constructor that takes both \tcode{key_container_type}
+and \tcode{mapped_container_type} arguments with containers of different sizes is
 undefined.
 
 \pnum
@@ -10389,14 +10389,14 @@ to \tcode{compare} is undefined.
 
 \indexlibrary{\idxcode{flatmap}!constructor}%
 \begin{itemdecl}
-flat_map(KeyContainer&& key_cont, MappedContainer&& mapped_cont);
+flat_map(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects Initializes \tcode{c.keys} with
-\tcode{std::forward<KeyContainer>(key_cont)} and \tcode{c.values} with
-\tcode{std::forward<MappedContainer>(mapped_cont)}; sorts the range
+\tcode{std::forward<key_container_type>(key_cont)} and \tcode{c.values} with
+\tcode{std::forward<mapped_container_type>(mapped_cont)}; sorts the range
 \range{begin()}{end()}.
 
 \pnum
@@ -10408,14 +10408,14 @@ is \tcode{key_cont.size()}.
 
 \indexlibrary{\idxcode{flatmap}!constructor}%
 \begin{itemdecl}
-flat_map(sorted_unique_t, KeyContainer&& key_cont, MappedContainer&& mapped_cont);
+flat_map(sorted_unique_t, key_container_type&& key_cont, mapped_container_type&& mapped_cont);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects Initializes \tcode{c.keys} with
-\tcode{std::forward<KeyContainer>(key_cont)} and \tcode{c.values} with
-\tcode{std::forward<MappedContainer>(mapped_cont)}.
+\tcode{std::forward<key_container_type>(key_cont)} and \tcode{c.values} with
+\tcode{std::forward<mapped_container_type>(mapped_cont)}.
 
 \pnum
 \complexity
@@ -10423,7 +10423,7 @@ Constant.
 \end{itemdescr}
 
 \begin{itemdecl}
-explicit flat_map(const Compare& comp);
+explicit flat_map(const key_compare& comp);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10439,7 +10439,7 @@ Constant.
 \begin{itemdecl}
 template <class InputIterator>
   flat_map(sorted_unique_t, InputIterator first, InputIterator last,
-           const Compare& comp = Compare());
+           const key_compare& comp = key_compare());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10479,7 +10479,7 @@ expressions.
 \indexlibrary{\idxcode{flatmap}!constructor}%
 \begin{itemdecl}
 template <class Alloc>
-  flat_map(const Compare& comp, const Alloc& a);
+  flat_map(const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10493,7 +10493,7 @@ uses-allocator construction\iref{allocator.uses.construction} of both
 \begin{itemdecl}
 template <class InputIterator, class Alloc>
   flat_map(InputIterator first, InputIterator last,
-           const Compare& comp, const Alloc& a);
+           const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10515,7 +10515,7 @@ and finally sorts the range \range{begin()}{end()}.
 \begin{itemdecl}
 template <class InputIterator, class Alloc>
   flat_map(sorted_unique_t, InputIterator first, InputIterator last,
-           const Compare& comp, const Alloc& a);
+           const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10563,7 +10563,7 @@ Equivalent to: \tcode{return try_emplace(move(x)).first->second;}
 \indexlibrary{\idxcode{at}!\idxcode{flatmap}}%
 \begin{itemdecl}
 mapped_type&       at(const key_type& x);
-const mapped_typeT& at(const key_type& x) const;
+const mapped_type& at(const key_type& x) const;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10584,14 +10584,14 @@ no such element is present.
 
 \indexlibrarymember{operator=}{flatmap}%
 \begin{itemdecl}
-flat_map& operator=(initializer_list<pair<Key, T>> il);
+flat_map& operator=(initializer_list<pair<key_type, mapped_type>> il);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{key_type} shall be \tcode{CopyInsertable} into \tcode{KeyContainer}, and
-\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{MappedContainer}
+\tcode{key_type} shall be \tcode{CopyInsertable} into \tcode{key_container_type}, and
+\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
 from \tcode{args...}.
 
 \pnum
@@ -10633,8 +10633,8 @@ template<class... Args>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{key_type} shall be \tcode{CopyInsertable} into \tcode{KeyContainer}, and
-\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{MappedContainer}
+\tcode{key_type} shall be \tcode{CopyInsertable} into \tcode{key_container_type}, and
+\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
 from \tcode{args...}.
 
 \pnum
@@ -10670,8 +10670,8 @@ template<class... Args>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{key_type} shall be \tcode{MoveInsertable} into \tcode{KeyContainer}, and
-\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{MappedContainer}
+\tcode{key_type} shall be \tcode{MoveInsertable} into \tcode{key_container_type}, and
+\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
 from \tcode{args...}.
 
 \pnum
@@ -10708,8 +10708,8 @@ template<class M>
 \pnum
 \requires
 \tcode{is_assignable_v<mapped_type\&, M} shall be \tcode{true}.
-\tcode{key_type} shall be \tcode{CopyInsertable} into \tcode{KeyContainer}, and
-\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{MappedContainer}
+\tcode{key_type} shall be \tcode{CopyInsertable} into \tcode{key_container_type}, and
+\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
 from \tcode{obj}.
 
 \pnum
@@ -10746,8 +10746,8 @@ template<class M>
 \pnum
 \requires
 \tcode{is_assignable_v<mapped_type\&, M>} shall be \tcode{true}.
-\tcode{key_type} shall be \tcode{MoveInsertable} into \tcode{KeyContainer}, and
-\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{MappedContainer}
+\tcode{key_type} shall be \tcode{MoveInsertable} into \tcode{key_container_type}, and
+\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
 from \tcode{obj}.
 
 \pnum
@@ -10789,7 +10789,7 @@ to \tcode{compare}.
 
 \indexlibrarymember{flatmap}{insert}%
 \begin{itemdecl}
-void insert(sorted_unique_t, initializer_list<pair<Key, T>> il);
+void insert(sorted_unique_t, initializer_list<pair<key_type, mapped_type>> il);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10813,7 +10813,7 @@ return temp;
 
 \indexlibrarymember{flatmap}{replace}%
 \begin{itemdecl}
-void replace(KeyContainer&& key_cont, MappedContainer&& mapped_cont);
+void replace(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -10970,10 +10970,10 @@ namespace std {
       // types:
       using key_type                  = Key;
       using mapped_type               = T;
-      using value_type                = pair<const Key, T>;
+      using value_type                = pair<const key_type, mapped_type>;
       using key_compare               = Compare;
-      using reference                 = pair<const Key&, T&>;
-      using const_reference           = pair<const Key&, const T&>;
+      using reference                 = pair<const key_type&, mapped_type&>;
+      using const_reference           = pair<const key_type&, const mapped_type&>;
       using size_type                 = size_t;
       using difference_type           = ptrdiff_t;
       using iterator                  = @\impdefx{type of \tcode{flat_multimap::iterator}}@; // see \ref{container.requirements}
@@ -10986,8 +10986,8 @@ namespace std {
       class value_compare {
         friend class flat_multimap;
       protected:
-        Compare comp;
-        value_compare(Compare c) : comp(c) { }
+        key_compare comp;
+        value_compare(key_compare c) : comp(c) { }
       public:
         bool operator()(const value_type& x, const value_type& y) const {
           return comp(x.first, y.first);
@@ -10996,58 +10996,58 @@ namespace std {
 
       struct containers
       {
-        KeyContainer keys;
-        MappedContainer values;
+        key_container_type keys;
+        mapped_container_type values;
       };
 
       // \ref{flatmultimap.cons}, construct/copy/destroy
       flat_multimap();
 
-      flat_multimap(KeyContainer&& key_cont, MappedContainer&& mapped_cont);
+      flat_multimap(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
       template <class Container>
         explicit flat_multimap(const Container& cont)
-          : flat_multimap(cont.begin(), cont.end(), Compare()) { }
+          : flat_multimap(cont.begin(), cont.end(), key_compare()) { }
       template <class Container, class Alloc>
         flat_multimap(const Container& cont, const Alloc& a)
-          : flat_multimap(cont.begin(), cont.end(), Compare(), a) { }
+          : flat_multimap(cont.begin(), cont.end(), key_compare(), a) { }
 
       flat_multimap(sorted_equivalent_t,
-                    KeyContainer&& key_cont, MappedContainer&& mapped_cont);
+                    key_container_type&& key_cont, mapped_container_type&& mapped_cont);
       template <class Container>
         flat_multimap(sorted_equivalent_t s, const Container& cont)
-          : flat_multimap(s, cont.begin(), cont.end(), Compare()) { }
+          : flat_multimap(s, cont.begin(), cont.end(), key_compare()) { }
       template <class Container, class Alloc>
         flat_multimap(sorted_equivalent_t s, const Container& cont, const Alloc& a)
-          : flat_multimap(s, cont.begin(), cont.end(), Compare(), a) { }
+          : flat_multimap(s, cont.begin(), cont.end(), key_compare(), a) { }
 
-      explicit flat_multimap(const Compare& comp);
+      explicit flat_multimap(const key_compare& comp);
       template <class Alloc>
-        flat_multimap(const Compare& comp, const Alloc& a);
+        flat_multimap(const key_compare& comp, const Alloc& a);
       template <class Alloc>
         explicit flat_multimap(const Alloc& a)
-          : flat_multimap(Compare(), a) { }
+          : flat_multimap(key_compare(), a) { }
 
       template <class InputIterator>
         flat_multimap(InputIterator first, InputIterator last,
-                      const Compare& comp = Compare());
+                      const key_compare& comp = key_compare());
       template <class InputIterator, class Alloc>
         flat_multimap(InputIterator first, InputIterator last,
-                     const Compare& comp, const Alloc& a);
+                     const key_compare& comp, const Alloc& a);
       template <class InputIterator, class Alloc>
         flat_multimap(InputIterator first, InputIterator last,
                       const Alloc& a)
-          : flat_multimap(first, last, Compare(), a) { }
+          : flat_multimap(first, last, key_compare(), a) { }
 
       template <class InputIterator>
         flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
-                      const Compare& comp = Compare());
+                      const key_compare& comp = key_compare());
       template <class InputIterator, class Alloc>
         flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
-                      const Compare& comp, const Alloc& a);
+                      const key_compare& comp, const Alloc& a);
       template <class InputIterator, class Alloc>
         flat_multimap(sorted_equivalent_t s, InputIterator first, InputIterator last,
                       const Alloc& a)
-          : flat_multimap(s, first, last, Compare(), a) { }
+          : flat_multimap(s, first, last, key_compare(), a) { }
 
       template <class Alloc>
         flat_multimap(const flat_multimap& m, const Alloc& a)
@@ -11060,30 +11060,30 @@ namespace std {
           , c{{m.c.keys, a}, {m.c.values, a}}
         {}
 
-      flat_multimap(initializer_list<pair<Key, T>>&& il,
-                    const Compare& comp = Compare())
+      flat_multimap(initializer_list<pair<key_type, mapped_type>>&& il,
+                    const key_compare& comp = key_compare())
           : flat_multimap(il, comp) { }
       template <class Alloc>
-        flat_multimap(initializer_list<pair<Key, T>>&& il,
-                      const Compare& comp, const Alloc& a)
+        flat_multimap(initializer_list<pair<key_type, mapped_type>>&& il,
+                      const key_compare& comp, const Alloc& a)
           : flat_multimap(il, comp, a) { }
       template <class Alloc>
-        flat_multimap(initializer_list<pair<Key, T>>&& il, const Alloc& a)
-          : flat_multimap(il, Compare(), a) { }
+        flat_multimap(initializer_list<pair<key_type, mapped_type>>&& il, const Alloc& a)
+          : flat_multimap(il, key_compare(), a) { }
 
-      flat_multimap(sorted_equivalent_t s, initializer_list<pair<Key, T>>&& il,
-                    const Compare& comp = Compare())
+      flat_multimap(sorted_equivalent_t s, initializer_list<pair<key_type, mapped_type>>&& il,
+                    const key_compare& comp = key_compare())
           : flat_multimap(s, il, comp) { }
       template <class Alloc>
-        flat_multimap(sorted_equivalent_t s, initializer_list<pair<Key, T>>&& il,
-                      const Compare& comp, const Alloc& a)
+        flat_multimap(sorted_equivalent_t s, initializer_list<pair<key_type, mapped_type>>&& il,
+                      const key_compare& comp, const Alloc& a)
           : flat_multimap(s, il, comp, a) { }
       template <class Alloc>
-        flat_multimap(sorted_equivalent_t s, initializer_list<pair<Key, T>>&& il,
+        flat_multimap(sorted_equivalent_t s, initializer_list<pair<key_type, mapped_type>>&& il,
                       const Alloc& a)
-          : flat_multimap(s, il, Compare(), a) { }
+          : flat_multimap(s, il, key_compare(), a) { }
 
-      flat_multimap& operator=(initializer_list<pair<Key, T>> il);
+      flat_multimap& operator=(initializer_list<pair<key_type, mapped_type>> il);
 
       // iterators
       iterator                begin() noexcept;
@@ -11121,11 +11121,11 @@ namespace std {
         void insert(InputIterator first, InputIterator last);
       template <class InputIterator>
         void insert(sorted_equivalent_t, InputIterator first, InputIterator last);
-      void insert(initializer_list<pair<Key, T>>);
-      void insert(sorted_equivalent_t, initializer_list<pair<Key, T>> il);
+      void insert(initializer_list<pair<key_type, mapped_type>>);
+      void insert(sorted_equivalent_t, initializer_list<pair<key_type, mapped_type>> il);
 
       containers extract() &&;
-      void replace(KeyContainer&& key_cont, MappedContainer&& mapped_cont);
+      void replace(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
 
       iterator erase(iterator position);
       iterator erase(const_iterator position);
@@ -11134,19 +11134,19 @@ namespace std {
 
       void swap(flat_multimap& fm)
         noexcept(
-          noexcept(declval<KeyContainer>().swap(declval<KeyContainer&>())) &&
-          noexcept(declval<MappedContainer>().swap(declval<MappedContainer&>()))
+          noexcept(declval<key_container_type>().swap(declval<key_container_type&>())) &&
+          noexcept(declval<mapped_container_type>().swap(declval<mapped_container_type&>()))
         );
       void clear() noexcept;
 
       template<class C2>
-        void merge(flat_multimap<Key, T, C2, KeyContainer, MappedContainer>& source);
+        void merge(flat_multimap<key_type, mapped_type, C2, key_container_type, mapped_container_type>& source);
       template<class C2>
-        void merge(flat_multimap<Key, T, C2, KeyContainer, MappedContainer>&& source);
+        void merge(flat_multimap<key_type, mapped_type, C2, key_container_type, mapped_container_type>&& source);
       template<class C2>
-        void merge(flat_map<Key, T, C2, KeyContainer, MappedContainer>& source);
+        void merge(flat_map<key_type, mapped_type, C2, key_container_type, mapped_container_type>& source);
       template<class C2>
-        void merge(flat_map<Key, T, C2, KeyContainer, MappedContainer>&& source);
+        void merge(flat_map<key_type, mapped_type, C2, key_container_type, mapped_container_type>&& source);
 
       // observers
       key_compare key_comp() const;
@@ -11182,8 +11182,8 @@ namespace std {
         pair<const_iterator, const_iterator> equal_range(const K& x) const;
 
   private:
-    containers c;    // \expos
-    Compare compare; // \expos
+    containers c;        // \expos
+    key_compare compare; // \expos
   };
 
   template<class Container>
@@ -11365,8 +11365,8 @@ namespace std {
 \rSec3[flatmultimap.cons]{Constructors}
 
 \pnum
-The effect of calling a constructor that takes both \tcode{KeyContainer}
-and \tcode{MappedContainer} arguments with containers of different sizes is
+The effect of calling a constructor that takes both \tcode{key_container_type}
+and \tcode{mapped_container_type} arguments with containers of different sizes is
 undefined.
 
 \pnum
@@ -11378,18 +11378,18 @@ expressions.
 \pnum
 The effect of calling a constructor that takes a \tcode{sorted_equivalent_t}
 argument with a container or containers that are not sorted with respect
-to \tcode{Compare} is undefined.
+to \tcode{key_compare} is undefined.
 
 \indexlibrary{\idxcode{flatmultimap}!constructor}%
 \begin{itemdecl}
-flat_multimap(KeyContainer&& key_cont, MappedContainer&& mapped_cont);
+flat_multimap(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects Initializes \tcode{c.keys} with
-\tcode{std::forward<KeyContainer>(key_cont)} and \tcode{c.values} with
-\tcode{std::forward<MappedContainer>(mapped_cont)}; sorts the range
+\tcode{std::forward<key_container_type>(key_cont)} and \tcode{c.values} with
+\tcode{std::forward<mapped_container_type>(mapped_cont)}; sorts the range
 +\range{begin()}{end()}.
 
 \pnum
@@ -11401,14 +11401,14 @@ is \tcode{key_cont.size()}.
 
 \indexlibrary{\idxcode{flatmultimap}!constructor}%
 \begin{itemdecl}
-flat_multimap(sorted_equivalent_t, KeyContainer&& key_cont, MappedContainer&& mapped_cont);
+flat_multimap(sorted_equivalent_t, key_container_type&& key_cont, mapped_container_type&& mapped_cont);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \effects Initializes \tcode{c.keys} with
-\tcode{std::forward<KeyContainer>(key_cont)} and \tcode{c.values} with
-\tcode{std::forward<MappedContainer>(mapped_cont)}.
+\tcode{std::forward<key_container_type>(key_cont)} and \tcode{c.values} with
+\tcode{std::forward<mapped_container_type>(mapped_cont)}.
 
 \pnum
 \complexity
@@ -11419,7 +11419,7 @@ Constant.
 \begin{itemdecl}
 template <class InputIterator>
   flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
-                const Compare& comp = Compare());
+                const key_compare& comp = key_compare());
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11459,7 +11459,7 @@ expressions.
 \indexlibrary{\idxcode{flatmultimap}!constructor}%
 \begin{itemdecl}
 template <class Alloc>
-  flat_multimap(const Compare& comp, const Alloc& a);
+  flat_multimap(const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11473,7 +11473,7 @@ uses-allocator construction\iref{allocator.uses.construction} of both
 \begin{itemdecl}
 template <class InputIterator, class Alloc>
   flat_multimap(InputIterator first, InputIterator last,
-                const Compare& comp, const Alloc& a);
+                const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11495,7 +11495,7 @@ and finally sorts the range \range{begin()}{end()}.
 \begin{itemdecl}
 template <class InputIterator, class Alloc>
   flat_multimap(sorted_equivalent_t, InputIterator first, InputIterator last,
-                const Compare& comp, const Alloc& a);
+                const key_compare& comp, const Alloc& a);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11520,14 +11520,14 @@ Linear.
 
 \indexlibrarymember{operator=}{flatmap}%
 \begin{itemdecl}
-flat_map& operator=(initializer_list<pair<Key, T>> il);
+flat_map& operator=(initializer_list<pair<key_type, mapped_type>> il);
 \end{itemdecl}
 
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{key_type} shall be \tcode{CopyInsertable} into \tcode{KeyContainer}, and
-\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{MappedContainer}
+\tcode{key_type} shall be \tcode{CopyInsertable} into \tcode{key_container_type}, and
+\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
 from \tcode{args...}.
 
 \pnum
@@ -11575,7 +11575,7 @@ to \tcode{compare}.
 
 \indexlibrarymember{flatmultimap}{insert}%
 \begin{itemdecl}
-void insert(sorted_unique_t, initializer_list<pair<Key, T>> il);
+void insert(sorted_unique_t, initializer_list<pair<key_type, mapped_type>> il);
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11599,7 +11599,7 @@ return temp;
 
 \indexlibrarymember{flatmultimap}{replace}%
 \begin{itemdecl}
-void replace(KeyContainer&& key_cont, MappedContainer&& mapped_cont);
+void replace(key_container_type&& key_cont, mapped_container_type&& mapped_cont);
 \end{itemdecl}
 
 \begin{itemdescr}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -12340,7 +12340,7 @@ void swap(flat_set& fs) noexcept;
 
 \begin{itemdescr}
 \pnum \constraints \tcode{is_nothrow_swappable_v<container_type> \&\&
-is_nothrow_swappable_v<key_compare>}
+is_nothrow_swappable_v<key_compare>} is \tcode{true}.
 
 \pnum \effects Equivalent to:
 \begin{codeblock}
@@ -12463,7 +12463,7 @@ template<class Key, class Compare, class Container>
 
 \begin{itemdescr}
 \pnum \constraints \tcode{is_nothrow_swappable_v<Container> \&\&
-is_nothrow_swappable_v<Compare>}
+is_nothrow_swappable_v<Compare>} is \tcode{true}.
 
 \pnum
 \effects Equivalent to: \tcode{x.swap(y)}.
@@ -12991,7 +12991,7 @@ void swap(flat_multiset& fms) noexcept;
 
 \begin{itemdescr}
 \pnum \constraints \tcode{is_nothrow_swappable_v<container_type> \&\&
-is_nothrow_swappable_v<key_compare>}
+is_nothrow_swappable_v<key_compare>} is \tcode{true}.
 
 \pnum \effects Equivalent to:
 \begin{codeblock}
@@ -13114,7 +13114,7 @@ template<class Key, class Compare, class Container>
 
 \begin{itemdescr}
 \pnum \constraints \tcode{is_nothrow_swappable_v<Container> \&\&
-is_nothrow_swappable_v<Compare>}
+is_nothrow_swappable_v<Compare>} is \tcode{true}.
 
 \pnum
 \effects Equivalent to: \tcode{x.swap(y)}.

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -9977,7 +9977,7 @@ namespace std {
         key_compare comp;
         value_compare(key_compare c) : comp(c) { }
       public:
-        bool operator()(const value_type& x, const value_type& y) const {
+        bool operator()(const_reference x, const_reference y) const {
           return comp(x.first, y.first);
         }
       };
@@ -11020,7 +11020,7 @@ namespace std {
         key_compare comp;
         value_compare(key_compare c) : comp(c) { }
       public:
-        bool operator()(const value_type& x, const value_type& y) const {
+        bool operator()(const_reference x, const_reference y) const {
           return comp(x.first, y.first);
         }
       };

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10248,10 +10248,7 @@ namespace std {
 
   template <class Container>
     flat_map(Container)
-      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>,
-                  less<@\placeholder{cont-key-type}@<Container>>,
-                  vector<@\placeholder{cont-key-type}@<Container>>,
-                  vector<@\placeholder{cont-mapped-type}@<Container>>>;
+      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>>;
 
   template <class KeyContainer, class MappedContainer>
     flat_map(KeyContainer, MappedContainer)
@@ -10262,10 +10259,7 @@ namespace std {
 
   template <class Container, class Alloc>
     flat_map(Container, Alloc)
-      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>,
-                  less<@\placeholder{cont-key-type}@<Container>>,
-                  vector<@\placeholder{cont-key-type}@<Container>>,
-                  vector<@\placeholder{cont-mapped-type}@<Container>>>;
+      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>>;
 
   template <class KeyContainer, class MappedContainer, class Alloc>
     flat_map(KeyContainer, MappedContainer, Alloc)
@@ -10276,10 +10270,7 @@ namespace std {
 
   template <class Container>
     flat_map(sorted_unique_t, Container)
-      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>,
-                  less<@\placeholder{cont-key-type}@<Container>>,
-                  vector<@\placeholder{cont-key-type}@<Container>>,
-                  vector<@\placeholder{cont-mapped-type}@<Container>>>;
+      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>>;
 
   template <class KeyContainer, class MappedContainer>
     flat_map(sorted_unique_t, KeyContainer, MappedContainer)
@@ -10290,10 +10281,7 @@ namespace std {
 
   template <class Container, class Alloc>
     flat_map(sorted_unique_t, Container, Alloc)
-      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>,
-                  less<@\placeholder{cont-key-type}@<Container>>,
-                  vector<@\placeholder{cont-key-type}@<Container>>,
-                  vector<@\placeholder{cont-mapped-type}@<Container>>>;
+      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>>;
 
   template <class KeyContainer, class MappedContainer, class Alloc>
     flat_map(sorted_unique_t, KeyContainer, MappedContainer, Alloc)
@@ -10304,65 +10292,51 @@ namespace std {
 
   template <class InputIterator, class Compare = less<@\placeholder{iter-mapped-type}@<InputIterator>>>
     flat_map(InputIterator, InputIterator, Compare = Compare())
-      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare,
-                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>,
-                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
+      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
   template<class InputIterator, class Compare, class Alloc>
     flat_map(InputIterator, InputIterator, Compare, Alloc)
-      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare,
-                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>,
-                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
+      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
   template<class InputIterator, class Alloc>
     flat_map(InputIterator, InputIterator, Alloc)
-      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
-                  less<@\placeholder{iter-mapped-type}@<InputIterator>>,
-                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>,
-                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
+      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>>;
 
   template <class InputIterator, class Compare = less<@\placeholder{iter-mapped-type}@<InputIterator>>>
     flat_map(sorted_unique_t, InputIterator, InputIterator, Compare = Compare())
-      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare,
-                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>,
-                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
+      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
   template<class InputIterator, class Compare, class Alloc>
     flat_map(sorted_unique_t, InputIterator, InputIterator, Compare, Alloc)
-      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare,
-                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>,
-                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
+      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
   template<class InputIterator, class Alloc>
     flat_map(sorted_unique_t, InputIterator, InputIterator, Alloc)
-      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
-                  less<@\placeholder{iter-mapped-type}@<InputIterator>>,
-                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>,
-                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
+      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>>;
 
   template<class Key, class T, class Compare = less<Key>>
     flat_map(initializer_list<pair<const Key, T>>, Compare = Compare())
-      -> flat_map<Key, T, Compare, vector<Key>, vector<T>>;
+      -> flat_map<Key, T, Compare>;
 
   template<class Key, class T, class Compare, class Alloc>
     flat_map(initializer_list<pair<const Key, T>>, Compare, Alloc)
-      -> flat_map<Key, T, Compare, vector<Key>, vector<T>>;
+      -> flat_map<Key, T, Compare>;
 
   template<class Key, class T, class Alloc>
     flat_map(initializer_list<pair<const Key, T>>, Alloc)
-      -> flat_map<Key, T, less<Key>, vector<Key>, vector<T>>;
+      -> flat_map<Key, T>;
 
   template<class Key, class T, class Compare = less<Key>>
   flat_map(sorted_unique_t, initializer_list<pair<const Key, T>>, Compare = Compare())
-      -> flat_map<Key, T, Compare, vector<Key>, vector<T>>;
+      -> flat_map<Key, T, Compare>;
 
   template<class Key, class T, class Compare, class Alloc>
     flat_map(sorted_unique_t, initializer_list<pair<const Key, T>>, Compare, Alloc)
-      -> flat_map<Key, T, Compare, vector<Key>, vector<T>>;
+      -> flat_map<Key, T, Compare>;
 
   template<class Key, class T, class Alloc>
     flat_map(sorted_unique_t, initializer_list<pair<const Key, T>>, Alloc)
-      -> flat_map<Key, T, less<Key>, vector<Key>, vector<T>>;
+      -> flat_map<Key, T>;
 }
 \end{codeblock}
 
@@ -11276,10 +11250,7 @@ namespace std {
 
   template <class Container>
     flat_multimap(Container)
-      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>,
-                       less<@\placeholder{cont-key-type}@<Container>>,
-                       vector<@\placeholder{cont-key-type}@<Container>>,
-                       vector<@\placeholder{cont-mapped-type}@<Container>>>;
+      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>>;
 
   template <class KeyContainer, class MappedContainer>
     flat_multimap(KeyContainer, MappedContainer)
@@ -11290,10 +11261,7 @@ namespace std {
 
   template <class Container, class Alloc>
     flat_multimap(Container, Alloc)
-      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>,
-                       less<@\placeholder{cont-key-type}@<Container>>,
-                       vector<@\placeholder{cont-key-type}@<Container>>,
-                       vector<@\placeholder{cont-mapped-type}@<Container>>>;
+      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>>;
 
   template <class KeyContainer, class MappedContainer, class Alloc>
     flat_multimap(KeyContainer, MappedContainer, Alloc)
@@ -11304,10 +11272,7 @@ namespace std {
 
   template <class Container>
     flat_multimap(sorted_equivalent_t, Container)
-      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>,
-                       less<@\placeholder{cont-key-type}@<Container>>,
-                       vector<@\placeholder{cont-key-type}@<Container>>,
-                       vector<@\placeholder{cont-mapped-type}@<Container>>>;
+      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>>;
 
   template <class KeyContainer, class MappedContainer>
     flat_multimap(sorted_equivalent_t, KeyContainer, MappedContainer)
@@ -11318,10 +11283,7 @@ namespace std {
 
   template <class Container, class Alloc>
     flat_multimap(sorted_equivalent_t, Container, Alloc)
-      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>,
-                       less<@\placeholder{cont-key-type}@<Container>>,
-                       vector<@\placeholder{cont-key-type}@<Container>>,
-                       vector<@\placeholder{cont-mapped-type}@<Container>>>;
+      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>>;
 
   template <class KeyContainer, class MappedContainer, class Alloc>
     flat_multimap(sorted_equivalent_t, KeyContainer, MappedContainer, Alloc)
@@ -11332,67 +11294,53 @@ namespace std {
 
   template <class InputIterator, class Compare = less<@\placeholder{iter-key-type}@<InputIterator>>>
     flat_multimap(InputIterator, InputIterator, Compare = Compare())
-      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare,
-                       vector<@\placeholder{iter-key-type}@<InputIterator>>,
-                       vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
+      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
   template<class InputIterator, class Compare, class Alloc>
     flat_multimap(InputIterator, InputIterator, Compare, Alloc)
-      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
-                       Compare, vector<@\placeholder{iter-key-type}@<InputIterator>>,
-                       vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
+      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
   template<class InputIterator, class Alloc>
     flat_multimap(InputIterator, InputIterator, Alloc)
-      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
-                       less<@\placeholder{iter-key-type}@<InputIterator>>,
-                       vector<@\placeholder{iter-key-type}@<InputIterator>>,
-                       vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
+      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>>;
 
   template <class InputIterator, class Compare = less<@\placeholder{iter-key-type}@<InputIterator>>>
     flat_multimap(sorted_equivalent_t, InputIterator, InputIterator,
                   Compare = Compare())
-      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare,
-                       vector<@\placeholder{iter-key-type}@<InputIterator>>,
-                       vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
+      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
   template<class InputIterator, class Compare, class Alloc>
     flat_multimap(sorted_equivalent_t, InputIterator, InputIterator, Compare, Alloc)
-      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
-                       Compare, vector<@\placeholder{iter-key-type}@<InputIterator>>,
-                       vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
+      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
   template<class InputIterator, class Alloc>
     flat_multimap(sorted_equivalent_t, InputIterator, InputIterator, Alloc)
-      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
-                       less<@\placeholder{iter-key-type}@<InputIterator>>,
-                       vector<@\placeholder{iter-key-type}@<InputIterator>>,
-                       vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
+      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>>;
 
   template<class Key, class T, class Compare = less<Key>>
     flat_multimap(initializer_list<pair<const Key, T>>, Compare = Compare())
-      -> flat_multimap<Key, T, Compare, vector<Key>, vector<T>>;
+      -> flat_multimap<Key, T, Compare>;
 
   template<class Key, class T, class Compare, class Alloc>
     flat_multimap(initializer_list<pair<const Key, T>>, Compare, Alloc)
-      -> flat_multimap<Key, T, Compare, vector<Key>, vector<T>>;
+      -> flat_multimap<Key, T, Compare>;
 
   template<class Key, class T, class Alloc>
     flat_multimap(initializer_list<pair<const Key, T>>, Alloc)
-      -> flat_multimap<Key, T, less<Key>, vector<Key>, vector<T>>;
+      -> flat_multimap<Key, T>;
 
   template<class Key, class T, class Compare = less<Key>>
   flat_multimap(sorted_equivalent_t, initializer_list<pair<const Key, T>>,
                 Compare = Compare())
-      -> flat_multimap<Key, T, Compare, vector<Key>, vector<T>>;
+      -> flat_multimap<Key, T, Compare>;
 
   template<class Key, class T, class Compare, class Alloc>
     flat_multimap(sorted_equivalent_t, initializer_list<pair<const Key, T>>, Compare, Alloc)
-      -> flat_multimap<Key, T, Compare, vector<Key>, vector<T>>;
+      -> flat_multimap<Key, T, Compare>;
 
   template<class Key, class T, class Alloc>
     flat_multimap(sorted_equivalent_t, initializer_list<pair<const Key, T>>, Alloc)
-      -> flat_multimap<Key, T, less<Key>, vector<Key>, vector<T>>;
+      -> flat_multimap<Key, T>;
 }
 \end{codeblock}
 

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10277,19 +10277,6 @@ namespace std {
                   less<typename KeyContainer::value_type>,
                   KeyContainer, MappedContainer>;
 
-  template<class Compare, class Alloc>
-    flat_map(Compare, Alloc)
-      -> flat_map<alloc_key_t<Alloc>, alloc_val_t<Alloc>, Compare,
-                  vector<alloc_key_t<Alloc>>,
-                  vector<alloc_val_t<Alloc>>>;
-
-  template<class Alloc>
-    flat_map(Alloc)
-      -> flat_map<alloc_key_t<Alloc>, alloc_val_t<Alloc>,
-                  less<alloc_key_t<Alloc>>,
-                  vector<alloc_key_t<Alloc>>,
-                  vector<alloc_val_t<Alloc>>>;
-
   template <class InputIterator, class Compare = less<iter_key_t<InputIterator>>>
     flat_map(InputIterator, InputIterator, Compare = Compare())
       -> flat_map<iter_key_t<InputIterator>, iter_val_t<InputIterator>,
@@ -11325,19 +11312,6 @@ namespace std {
                        typename MappedContainer::value_type,
                        less<typename KeyContainer::value_type>,
                        KeyContainer, MappedContainer>;
-
-  template<class Compare, class Alloc>
-    flat_multimap(Compare, Alloc)
-      -> flat_multimap<alloc_key_t<Alloc>, alloc_val_t<Alloc>, Compare,
-                       vector<alloc_key_t<Alloc>>,
-                       vector<alloc_val_t<Alloc>>>;
-
-  template<class Alloc>
-    flat_multimap(Alloc)
-      -> flat_multimap<alloc_key_t<Alloc>, alloc_val_t<Alloc>,
-                       less<alloc_key_t<Alloc>>,
-                       vector<alloc_key_t<Alloc>>,
-                       vector<alloc_val_t<Alloc>>>;
 
   template <class InputIterator, class Compare = less<iter_key_t<InputIterator>>>
     flat_multimap(InputIterator, InputIterator, Compare = Compare())

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -755,7 +755,7 @@ because it has a fixed number of elements. The library also provides container
 adaptors that make it easy to construct abstract data types, such
 as \tcode{stack}s, \tcode{queue}s, \added{\tcode{flat_map}s,
 or \tcode{flat_multimap}s, }out of the basic sequence container kinds (or out
-of other kinds of sequence containers that the user might define).
+of other kinds of sequence containers).
 
 \pnum
 \begin{note}
@@ -1500,7 +1500,7 @@ and
 \tcode{multimap}.\added{  The library also provides container adaptors that
 make it easy to construct abstract data types, such as \tcode{flat_map}s
 or \tcode{flat_multimap}s, out of the basic sequence container kinds (or out
-of other program-defined sequence containers that the user might define).}
+of other program-defined sequence containers).}
 
 \pnum
 Each associative container is parameterized on

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -8908,9 +8908,9 @@ for the first form, or from the range
 \rSec2[container.adaptors.general]{In general}
 
 \pnum
-The headers \tcode{<queue>}\changed{ and}{,} \tcode{<stack>}\added{,
-and \tcode{<flat_map>}} define the container adaptors
-\tcode{queue}, \tcode{priority_queue}\changed{ and}{,} \tcode{stack}\added{,
+The headers \tcode{<queue>}\changed{ and}{,} \tcode{<stack>}\added{, and
+\tcode{<flat_map>}} define the container adaptors \tcode{queue},
+\tcode{priority_queue}\changed{ and}{,} \tcode{stack}\added{, and
 \tcode{flat_map}}.
 
 \pnum
@@ -9044,8 +9044,7 @@ namespace std {
   template<class Key, class T, class Compare,
            class KeyContainer, class MappedContainer>
     void swap(flat_map<Key, T, Compare, KeyContainer, MappedContainer>& x,
-              flat_map<Key, T, Compare, KeyContainer, MappedContainer>& y)
-      noexcept(noexcept(x.swap(y)));
+              flat_map<Key, T, Compare, KeyContainer, MappedContainer>& y) noexcept;
 
   struct sorted_unique_t { explicit sorted_unique_t() = default; };
   inline constexpr sorted_unique_t sorted_unique {};
@@ -9083,8 +9082,7 @@ namespace std {
   template<class Key, class T, class Compare,
            class KeyContainer, class MappedContainer>
     void swap(flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& x,
-              flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& y)
-      noexcept(noexcept(x.swap(y)));
+              flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& y) noexcept;
 
   struct sorted_equivalent_t { explicit sorted_equivalent_t() = default; };
   inline constexpr sorted_equivalent_t sorted_equivalent {};
@@ -9932,11 +9930,10 @@ a \tcode{flat_map<Key,T>} the \tcode{key_type} is \tcode{Key} and the
 
 \pnum
 A \tcode{flat_map} \tcode{m} maintains these invariants: it contains the same
-number of keys and values; the keys are sorted with respect to the its
+number of keys and values; the keys are sorted with respect to the
 comparison object; and the value at offset \tcode{o} within the value
 container is the value associated with the key at offset \tcode{o} within the
-key container.  That is, this key-value pair is used to form the
-value \tcode{*(m.begin() + o)}.
+key container.
 
 \pnum
 Descriptions are provided here only for operations on \tcode{flat_map} that
@@ -10290,68 +10287,66 @@ namespace std {
                   less<typename KeyContainer::value_type>,
                   KeyContainer, MappedContainer>;
 
-  template <class InputIterator, class Compare = less<iter_key_t<InputIterator>>>
+  template <class InputIterator, class Compare = less<@\placeholder{iter-mapped-type}@<InputIterator>>>
     flat_map(InputIterator, InputIterator, Compare = Compare())
-      -> flat_map<iter_key_t<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
-                  less<iter_key_t<InputIterator>>,
-                  vector<iter_key_t<InputIterator>>,
+      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare,
+                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>,
                   vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
   template<class InputIterator, class Compare, class Alloc>
     flat_map(InputIterator, InputIterator, Compare, Alloc)
-      -> flat_map<iter_key_t<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare,
-                  vector<iter_key_t<InputIterator>>,
+      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare,
+                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>,
                   vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
   template<class InputIterator, class Alloc>
     flat_map(InputIterator, InputIterator, Alloc)
-      -> flat_map<iter_key_t<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
-                  less<iter_key_t<InputIterator>>,
-                  vector<iter_key_t<InputIterator>>,
+      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
+                  less<@\placeholder{iter-mapped-type}@<InputIterator>>,
+                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>,
                   vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
-  template <class InputIterator, class Compare = less<iter_key_t<InputIterator>>>
+  template <class InputIterator, class Compare = less<@\placeholder{iter-mapped-type}@<InputIterator>>>
     flat_map(sorted_unique_t, InputIterator, InputIterator, Compare = Compare())
-      -> flat_map<iter_key_t<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
-                  less<iter_key_t<InputIterator>>,
-                  vector<iter_key_t<InputIterator>>,
+      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare,
+                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>,
                   vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
   template<class InputIterator, class Compare, class Alloc>
     flat_map(sorted_unique_t, InputIterator, InputIterator, Compare, Alloc)
-      -> flat_map<iter_key_t<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare,
-                  vector<iter_key_t<InputIterator>>,
+      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare,
+                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>,
                   vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
   template<class InputIterator, class Alloc>
     flat_map(sorted_unique_t, InputIterator, InputIterator, Alloc)
-      -> flat_map<iter_key_t<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
-                  less<iter_key_t<InputIterator>>,
-                  vector<iter_key_t<InputIterator>>,
+      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
+                  less<@\placeholder{iter-mapped-type}@<InputIterator>>,
+                  vector<@\placeholder{iter-mapped-type}@<InputIterator>>,
                   vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
   template<class Key, class T, class Compare = less<Key>>
-    flat_map(initializer_list<pair<Key, T>>, Compare = Compare())
+    flat_map(initializer_list<pair<const Key, T>>, Compare = Compare())
       -> flat_map<Key, T, Compare, vector<Key>, vector<T>>;
 
   template<class Key, class T, class Compare, class Alloc>
-    flat_map(initializer_list<pair<Key, T>>, Compare, Alloc)
+    flat_map(initializer_list<pair<const Key, T>>, Compare, Alloc)
       -> flat_map<Key, T, Compare, vector<Key>, vector<T>>;
 
   template<class Key, class T, class Alloc>
-    flat_map(initializer_list<pair<Key, T>>, Alloc)
+    flat_map(initializer_list<pair<const Key, T>>, Alloc)
       -> flat_map<Key, T, less<Key>, vector<Key>, vector<T>>;
 
   template<class Key, class T, class Compare = less<Key>>
-  flat_map(sorted_unique_t, initializer_list<pair<Key, T>>, Compare = Compare())
+  flat_map(sorted_unique_t, initializer_list<pair<const Key, T>>, Compare = Compare())
       -> flat_map<Key, T, Compare, vector<Key>, vector<T>>;
 
   template<class Key, class T, class Compare, class Alloc>
-    flat_map(sorted_unique_t, initializer_list<pair<Key, T>>, Compare, Alloc)
+    flat_map(sorted_unique_t, initializer_list<pair<const Key, T>>, Compare, Alloc)
       -> flat_map<Key, T, Compare, vector<Key>, vector<T>>;
 
   template<class Key, class T, class Alloc>
-    flat_map(sorted_unique_t, initializer_list<pair<Key, T>>, Alloc)
+    flat_map(sorted_unique_t, initializer_list<pair<const Key, T>>, Alloc)
       -> flat_map<Key, T, less<Key>, vector<Key>, vector<T>>;
 }
 \end{codeblock}
@@ -10600,11 +10595,6 @@ flat_map& operator=(initializer_list<value_type> il);
 
 \begin{itemdescr}
 \pnum
-\requires
-\tcode{key_type} shall be \tcode{CopyInsertable} into \tcode{key_container_type}, and
-\tcode{mapped_type} shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}.
-
-\pnum
 \effects Equivalent to:
 \begin{codeblock}
 clear();
@@ -10751,7 +10741,7 @@ template<class M>
 \begin{itemdescr}
 \pnum
 \requires
-\tcode{is_assignable_v<mapped_type\&, M} shall be \tcode{true}.
+\tcode{is_assignable_v<mapped_type\&, M>} shall be \tcode{true}.
 \tcode{key_type} shall be \tcode{CopyInsertable} into \tcode{key_container_type}, and
 \tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
 from \tcode{obj}.
@@ -10974,8 +10964,7 @@ template<class Key, class T, class Compare, class KeyContainer, class MappedCont
 \begin{itemdecl}
 template<class Key, class T, class Compare, class KeyContainer, class MappedContainer>
   void swap(flat_map<Key, T, Compare, KeyContainer, MappedContainer>& x,
-            flat_map<Key, T, Compare, KeyContainer, MappedContainer>& y)
-    noexcept(noexcept(x.swap(y)));
+            flat_map<Key, T, Compare, KeyContainer, MappedContainer>& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -11021,11 +11010,10 @@ a \tcode{flat_multimap<Key,T>} the \tcode{key_type} is \tcode{Key} and the
 
 \pnum
 A \tcode{flat_multimap} \tcode{m} maintains these invariants: it contains the
-same number of keys and values; the keys are sorted with respect to the its
+same number of keys and values; the keys are sorted with respect to the
 comparison object; and the value at offset \tcode{o} within the value
 container is the value associated with the key at offset \tcode{o} within the
-key container.  That is, this key-value pair is used to form the
-value \tcode{*(m.begin() + o)}.
+key container.
 
 \pnum
 Descriptions are provided here only for operations on \tcode{flat_multimap}
@@ -11353,8 +11341,7 @@ namespace std {
 
   template <class InputIterator, class Compare = less<@\placeholder{iter-key-type}@<InputIterator>>>
     flat_multimap(InputIterator, InputIterator, Compare = Compare())
-      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
-                       less<@\placeholder{iter-key-type}@<InputIterator>>,
+      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare,
                        vector<@\placeholder{iter-key-type}@<InputIterator>>,
                        vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
@@ -11374,8 +11361,7 @@ namespace std {
   template <class InputIterator, class Compare = less<@\placeholder{iter-key-type}@<InputIterator>>>
     flat_multimap(sorted_equivalent_t, InputIterator, InputIterator,
                   Compare = Compare())
-      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>,
-                       less<@\placeholder{iter-key-type}@<InputIterator>>,
+      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare,
                        vector<@\placeholder{iter-key-type}@<InputIterator>>,
                        vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
@@ -11393,28 +11379,28 @@ namespace std {
                        vector<@\placeholder{iter-mapped-type}@<InputIterator>>>;
 
   template<class Key, class T, class Compare = less<Key>>
-    flat_multimap(initializer_list<pair<Key, T>>, Compare = Compare())
+    flat_multimap(initializer_list<pair<const Key, T>>, Compare = Compare())
       -> flat_multimap<Key, T, Compare, vector<Key>, vector<T>>;
 
   template<class Key, class T, class Compare, class Alloc>
-    flat_multimap(initializer_list<pair<Key, T>>, Compare, Alloc)
+    flat_multimap(initializer_list<pair<const Key, T>>, Compare, Alloc)
       -> flat_multimap<Key, T, Compare, vector<Key>, vector<T>>;
 
   template<class Key, class T, class Alloc>
-    flat_multimap(initializer_list<pair<Key, T>>, Alloc)
+    flat_multimap(initializer_list<pair<const Key, T>>, Alloc)
       -> flat_multimap<Key, T, less<Key>, vector<Key>, vector<T>>;
 
   template<class Key, class T, class Compare = less<Key>>
-  flat_multimap(sorted_equivalent_t, initializer_list<pair<Key, T>>,
+  flat_multimap(sorted_equivalent_t, initializer_list<pair<const Key, T>>,
                 Compare = Compare())
       -> flat_multimap<Key, T, Compare, vector<Key>, vector<T>>;
 
   template<class Key, class T, class Compare, class Alloc>
-    flat_multimap(sorted_equivalent_t, initializer_list<pair<Key, T>>, Compare, Alloc)
+    flat_multimap(sorted_equivalent_t, initializer_list<pair<const Key, T>>, Compare, Alloc)
       -> flat_multimap<Key, T, Compare, vector<Key>, vector<T>>;
 
   template<class Key, class T, class Alloc>
-    flat_multimap(sorted_equivalent_t, initializer_list<pair<Key, T>>, Alloc)
+    flat_multimap(sorted_equivalent_t, initializer_list<pair<const Key, T>>, Alloc)
       -> flat_multimap<Key, T, less<Key>, vector<Key>, vector<T>>;
 }
 \end{codeblock}
@@ -11581,11 +11567,6 @@ flat_map& operator=(initializer_list<value_type> il);
 \end{itemdecl}
 
 \begin{itemdescr}
-\pnum
-\requires
-\tcode{key_type} shall be \tcode{CopyInsertable} into \tcode{key_container_type}, and
-\tcode{mapped_type}  shall be \tcode{EmplaceConstructible} into \tcode{mapped_container_type}
-from \tcode{args...}.
 
 \pnum
 \effects Equivalent to:
@@ -11880,8 +11861,7 @@ template<class Key, class T, class Compare, class KeyContainer, class MappedCont
 \begin{itemdecl}
 template<class Key, class T, class Compare, class KeyContainer, class MappedContainer>
   void swap(flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& x,
-            flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& y)
-    noexcept(noexcept(x.swap(y)));
+            flat_multimap<Key, T, Compare, KeyContainer, MappedContainer>& y) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
Since these constructors pass the given `const Alloc& a` to *both* KeyContainer and MappedContainer, it stands to reason that *both* containers must accept such an allocator according to `uses_allocator_v`. If *either* container doesn't accept `Alloc`, then we shouldn't be trying to use this constructor overload.

Arguably it could do something other than SFINAE away in the case that one-but-not-both of the containers accepted the allocator — for example it could have undefined behavior, or `static_assert` — but I'm fairly sure that's not an optimal outcome.

An example constructor affected by this wording:

>     template <class Alloc>
>       flat_map(const key_compare& comp, const Alloc& a);
>
> Effects: Initializes `compare` with `comp`, and performs uses-allocator construction (23.10.8.2) of both `c.keys` and `c.values `with `a`.
