### PR TITLE
Replace "Alloc" with "Allocator" in deduction guides

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -12084,64 +12084,64 @@ namespace std {
     flat_set(Container)
       -> flat_set<@\placeholder{cont-value-type}@<Container>>;
 
-  template <class Container, class Alloc>
-    flat_set(Container, Alloc)
+  template <class Container, class Allocator>
+    flat_set(Container, Allocator)
       -> flat_set<@\placeholder{cont-value-type}@<Container>>;
 
   template <class Container>
     flat_set(sorted_unique_t, Container)
       -> flat_set<@\placeholder{cont-value-type}@<Container>>;
 
-  template <class Container, class Alloc>
-    flat_set(sorted_unique_t, Container, Alloc)
+  template <class Container, class Allocator>
+    flat_set(sorted_unique_t, Container, Allocator)
       -> flat_set<@\placeholder{cont-value-type}@<Container>>;
 
   template <class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
     flat_set(InputIterator, InputIterator, Compare = Compare())
       -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Compare, class Alloc>
-    flat_set(InputIterator, InputIterator, Compare, Alloc)
+  template<class InputIterator, class Compare, class Allocator>
+    flat_set(InputIterator, InputIterator, Compare, Allocator)
       -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Alloc>
-    flat_set(InputIterator, InputIterator, Alloc)
+  template<class InputIterator, class Allocator>
+    flat_set(InputIterator, InputIterator, Allocator)
       -> flat_set<@\placeholder{iter-value-type}@<InputIterator>>;
 
   template <class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
     flat_set(sorted_unique_t, InputIterator, InputIterator, Compare = Compare())
       -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Compare, class Alloc>
-    flat_set(sorted_unique_t, InputIterator, InputIterator, Compare, Alloc)
+  template<class InputIterator, class Compare, class Allocator>
+    flat_set(sorted_unique_t, InputIterator, InputIterator, Compare, Allocator)
       -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Alloc>
-    flat_set(sorted_unique_t, InputIterator, InputIterator, Alloc)
+  template<class InputIterator, class Allocator>
+    flat_set(sorted_unique_t, InputIterator, InputIterator, Allocator)
       -> flat_set<@\placeholder{iter-value-type}@<InputIterator>>;
 
   template<class Key, class Compare = less<Key>>
     flat_set(initializer_list<Key>, Compare = Compare())
       -> flat_set<Key, Compare>;
 
-  template<class Key, class Compare, class Alloc>
-    flat_set(initializer_list<Key>, Compare, Alloc)
+  template<class Key, class Compare, class Allocator>
+    flat_set(initializer_list<Key>, Compare, Allocator)
       -> flat_set<Key, Compare>;
 
-  template<class Key, class Alloc>
-    flat_set(initializer_list<Key>, Alloc)
+  template<class Key, class Allocator>
+    flat_set(initializer_list<Key>, Allocator)
       -> flat_set<Key>;
 
   template<class Key, class Compare = less<Key>>
     flat_set(sorted_unique_t, initializer_list<Key>, Compare = Compare())
       -> flat_set<Key, Compare>;
 
-  template<class Key, class Compare, class Alloc>
-    flat_set(sorted_unique_t, initializer_list<Key>, Compare, Alloc)
+  template<class Key, class Compare, class Allocator>
+    flat_set(sorted_unique_t, initializer_list<Key>, Compare, Allocator)
       -> flat_set<Key, Compare>;
 
-  template<class Key, class Alloc>
-    flat_set(sorted_unique_t, initializer_list<Key>, Alloc)
+  template<class Key, class Allocator>
+    flat_set(sorted_unique_t, initializer_list<Key>, Allocator)
       -> flat_set<Key>;
 }
 \end{codeblock}
@@ -12747,64 +12747,64 @@ class flat_multiset {
     flat_multiset(Container)
       -> flat_multiset<@\placeholder{cont-value-type}@<Container>>;
 
-  template <class Container, class Alloc>
-    flat_multiset(Container, Alloc)
+  template <class Container, class Allocator>
+    flat_multiset(Container, Allocator)
       -> flat_multiset<@\placeholder{cont-value-type}@<Container>>;
 
   template <class Container>
     flat_multiset(sorted_equivalent_t, Container)
       -> flat_multiset<@\placeholder{cont-value-type}@<Container>>;
 
-  template <class Container, class Alloc>
-    flat_multiset(sorted_equivalent_t, Container, Alloc)
+  template <class Container, class Allocator>
+    flat_multiset(sorted_equivalent_t, Container, Allocator)
       -> flat_multiset<@\placeholder{cont-value-type}@<Container>>;
 
   template <class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
     flat_multiset(InputIterator, InputIterator, Compare = Compare())
       -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Compare, class Alloc>
-    flat_multiset(InputIterator, InputIterator, Compare, Alloc)
+  template<class InputIterator, class Compare, class Allocator>
+    flat_multiset(InputIterator, InputIterator, Compare, Allocator)
       -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Alloc>
-    flat_multiset(InputIterator, InputIterator, Alloc)
+  template<class InputIterator, class Allocator>
+    flat_multiset(InputIterator, InputIterator, Allocator)
       -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>>;
 
   template <class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
     flat_multiset(sorted_equivalent_t, InputIterator, InputIterator, Compare = Compare())
       -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Compare, class Alloc>
-    flat_multiset(sorted_equivalent_t, InputIterator, InputIterator, Compare, Alloc)
+  template<class InputIterator, class Compare, class Allocator>
+    flat_multiset(sorted_equivalent_t, InputIterator, InputIterator, Compare, Allocator)
       -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Alloc>
-    flat_multiset(sorted_equivalent_t, InputIterator, InputIterator, Alloc)
+  template<class InputIterator, class Allocator>
+    flat_multiset(sorted_equivalent_t, InputIterator, InputIterator, Allocator)
       -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>>;
 
   template<class Key, class Compare = less<Key>>
     flat_multiset(initializer_list<Key>, Compare = Compare())
       -> flat_multiset<Key, Compare>;
 
-  template<class Key, class Compare, class Alloc>
-    flat_multiset(initializer_list<Key>, Compare, Alloc)
+  template<class Key, class Compare, class Allocator>
+    flat_multiset(initializer_list<Key>, Compare, Allocator)
       -> flat_multiset<Key, Compare>;
 
-  template<class Key, class Alloc>
-    flat_multiset(initializer_list<Key>, Alloc)
+  template<class Key, class Allocator>
+    flat_multiset(initializer_list<Key>, Allocator)
       -> flat_multiset<Key>;
 
   template<class Key, class Compare = less<Key>>
   flat_multiset(sorted_equivalent_t, initializer_list<Key>, Compare = Compare())
       -> flat_multiset<Key, Compare>;
 
-  template<class Key, class Compare, class Alloc>
-    flat_multiset(sorted_equivalent_t, initializer_list<Key>, Compare, Alloc)
+  template<class Key, class Compare, class Allocator>
+    flat_multiset(sorted_equivalent_t, initializer_list<Key>, Compare, Allocator)
       -> flat_multiset<Key, Compare>;
 
-  template<class Key, class Alloc>
-  flat_multiset(sorted_equivalent_t, initializer_list<Key>, Alloc)
+  template<class Key, class Allocator>
+  flat_multiset(sorted_equivalent_t, initializer_list<Key>, Allocator)
       -> flat_multiset<Key>;
 }
 \end{codeblock}

--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10321,12 +10321,12 @@ namespace std {
                   less<typename KeyContainer::value_type>,
                   KeyContainer, MappedContainer>;
 
-  template <class Container, class Alloc>
-    flat_map(Container, Alloc)
+  template <class Container, class Allocator>
+    flat_map(Container, Allocator)
       -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>>;
 
-  template <class KeyContainer, class MappedContainer, class Alloc>
-    flat_map(KeyContainer, MappedContainer, Alloc)
+  template <class KeyContainer, class MappedContainer, class Allocator>
+    flat_map(KeyContainer, MappedContainer, Allocator)
       -> flat_map<typename KeyContainer::value_type,
                   typename MappedContainer::value_type,
                   less<typename KeyContainer::value_type>,
@@ -10343,12 +10343,12 @@ namespace std {
                   less<typename KeyContainer::value_type>,
                   KeyContainer, MappedContainer>;
 
-  template <class Container, class Alloc>
-    flat_map(sorted_unique_t, Container, Alloc)
+  template <class Container, class Allocator>
+    flat_map(sorted_unique_t, Container, Allocator)
       -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>>;
 
-  template <class KeyContainer, class MappedContainer, class Alloc>
-    flat_map(sorted_unique_t, KeyContainer, MappedContainer, Alloc)
+  template <class KeyContainer, class MappedContainer, class Allocator>
+    flat_map(sorted_unique_t, KeyContainer, MappedContainer, Allocator)
       -> flat_map<typename KeyContainer::value_type,
                   typename MappedContainer::value_type,
                   less<typename KeyContainer::value_type>,
@@ -10358,48 +10358,48 @@ namespace std {
     flat_map(InputIterator, InputIterator, Compare = Compare())
       -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Compare, class Alloc>
-    flat_map(InputIterator, InputIterator, Compare, Alloc)
+  template<class InputIterator, class Compare, class Allocator>
+    flat_map(InputIterator, InputIterator, Compare, Allocator)
       -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Alloc>
-    flat_map(InputIterator, InputIterator, Alloc)
+  template<class InputIterator, class Allocator>
+    flat_map(InputIterator, InputIterator, Allocator)
       -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>>;
 
   template <class InputIterator, class Compare = less<@\placeholder{iter-mapped-type}@<InputIterator>>>
     flat_map(sorted_unique_t, InputIterator, InputIterator, Compare = Compare())
       -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Compare, class Alloc>
-    flat_map(sorted_unique_t, InputIterator, InputIterator, Compare, Alloc)
+  template<class InputIterator, class Compare, class Allocator>
+    flat_map(sorted_unique_t, InputIterator, InputIterator, Compare, Allocator)
       -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Alloc>
-    flat_map(sorted_unique_t, InputIterator, InputIterator, Alloc)
+  template<class InputIterator, class Allocator>
+    flat_map(sorted_unique_t, InputIterator, InputIterator, Allocator)
       -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>>;
 
   template<class Key, class T, class Compare = less<Key>>
     flat_map(initializer_list<pair<Key, T>>, Compare = Compare())
       -> flat_map<Key, T, Compare>;
 
-  template<class Key, class T, class Compare, class Alloc>
-    flat_map(initializer_list<pair<Key, T>>, Compare, Alloc)
+  template<class Key, class T, class Compare, class Allocator>
+    flat_map(initializer_list<pair<Key, T>>, Compare, Allocator)
       -> flat_map<Key, T, Compare>;
 
-  template<class Key, class T, class Alloc>
-    flat_map(initializer_list<pair<Key, T>>, Alloc)
+  template<class Key, class T, class Allocator>
+    flat_map(initializer_list<pair<Key, T>>, Allocator)
       -> flat_map<Key, T>;
 
   template<class Key, class T, class Compare = less<Key>>
   flat_map(sorted_unique_t, initializer_list<pair<Key, T>>, Compare = Compare())
       -> flat_map<Key, T, Compare>;
 
-  template<class Key, class T, class Compare, class Alloc>
-    flat_map(sorted_unique_t, initializer_list<pair<Key, T>>, Compare, Alloc)
+  template<class Key, class T, class Compare, class Allocator>
+    flat_map(sorted_unique_t, initializer_list<pair<Key, T>>, Compare, Allocator)
       -> flat_map<Key, T, Compare>;
 
-  template<class Key, class T, class Alloc>
-    flat_map(sorted_unique_t, initializer_list<pair<Key, T>>, Alloc)
+  template<class Key, class T, class Allocator>
+    flat_map(sorted_unique_t, initializer_list<pair<Key, T>>, Allocator)
       -> flat_map<Key, T>;
 }
 \end{codeblock}
@@ -11318,12 +11318,12 @@ namespace std {
                        less<typename KeyContainer::value_type>,
                        KeyContainer, MappedContainer>;
 
-  template <class Container, class Alloc>
-    flat_multimap(Container, Alloc)
+  template <class Container, class Allocator>
+    flat_multimap(Container, Allocator)
       -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>>;
 
-  template <class KeyContainer, class MappedContainer, class Alloc>
-    flat_multimap(KeyContainer, MappedContainer, Alloc)
+  template <class KeyContainer, class MappedContainer, class Allocator>
+    flat_multimap(KeyContainer, MappedContainer, Allocator)
       -> flat_multimap<typename KeyContainer::value_type,
                        typename MappedContainer::value_type,
                        less<typename KeyContainer::value_type>,
@@ -11340,12 +11340,12 @@ namespace std {
                        less<typename KeyContainer::value_type>,
                        KeyContainer, MappedContainer>;
 
-  template <class Container, class Alloc>
-    flat_multimap(sorted_equivalent_t, Container, Alloc)
+  template <class Container, class Allocator>
+    flat_multimap(sorted_equivalent_t, Container, Allocator)
       -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>>;
 
-  template <class KeyContainer, class MappedContainer, class Alloc>
-    flat_multimap(sorted_equivalent_t, KeyContainer, MappedContainer, Alloc)
+  template <class KeyContainer, class MappedContainer, class Allocator>
+    flat_multimap(sorted_equivalent_t, KeyContainer, MappedContainer, Allocator)
       -> flat_multimap<typename KeyContainer::value_type,
                        typename MappedContainer::value_type,
                        less<typename KeyContainer::value_type>,
@@ -11355,12 +11355,12 @@ namespace std {
     flat_multimap(InputIterator, InputIterator, Compare = Compare())
       -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Compare, class Alloc>
-    flat_multimap(InputIterator, InputIterator, Compare, Alloc)
+  template<class InputIterator, class Compare, class Allocator>
+    flat_multimap(InputIterator, InputIterator, Compare, Allocator)
       -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Alloc>
-    flat_multimap(InputIterator, InputIterator, Alloc)
+  template<class InputIterator, class Allocator>
+    flat_multimap(InputIterator, InputIterator, Allocator)
       -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>>;
 
   template <class InputIterator, class Compare = less<@\placeholder{iter-key-type}@<InputIterator>>>
@@ -11368,24 +11368,24 @@ namespace std {
                   Compare = Compare())
       -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Compare, class Alloc>
-    flat_multimap(sorted_equivalent_t, InputIterator, InputIterator, Compare, Alloc)
+  template<class InputIterator, class Compare, class Allocator>
+    flat_multimap(sorted_equivalent_t, InputIterator, InputIterator, Compare, Allocator)
       -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Alloc>
-    flat_multimap(sorted_equivalent_t, InputIterator, InputIterator, Alloc)
+  template<class InputIterator, class Allocator>
+    flat_multimap(sorted_equivalent_t, InputIterator, InputIterator, Allocator)
       -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>>;
 
   template<class Key, class T, class Compare = less<Key>>
     flat_multimap(initializer_list<pair<Key, T>>, Compare = Compare())
       -> flat_multimap<Key, T, Compare>;
 
-  template<class Key, class T, class Compare, class Alloc>
-    flat_multimap(initializer_list<pair<Key, T>>, Compare, Alloc)
+  template<class Key, class T, class Compare, class Allocator>
+    flat_multimap(initializer_list<pair<Key, T>>, Compare, Allocator)
       -> flat_multimap<Key, T, Compare>;
 
-  template<class Key, class T, class Alloc>
-    flat_multimap(initializer_list<pair<Key, T>>, Alloc)
+  template<class Key, class T, class Allocator>
+    flat_multimap(initializer_list<pair<Key, T>>, Allocator)
       -> flat_multimap<Key, T>;
 
   template<class Key, class T, class Compare = less<Key>>
@@ -11393,12 +11393,12 @@ namespace std {
                 Compare = Compare())
       -> flat_multimap<Key, T, Compare>;
 
-  template<class Key, class T, class Compare, class Alloc>
-    flat_multimap(sorted_equivalent_t, initializer_list<pair<Key, T>>, Compare, Alloc)
+  template<class Key, class T, class Compare, class Allocator>
+    flat_multimap(sorted_equivalent_t, initializer_list<pair<Key, T>>, Compare, Allocator)
       -> flat_multimap<Key, T, Compare>;
 
-  template<class Key, class T, class Alloc>
-    flat_multimap(sorted_equivalent_t, initializer_list<pair<Key, T>>, Alloc)
+  template<class Key, class T, class Allocator>
+    flat_multimap(sorted_equivalent_t, initializer_list<pair<Key, T>>, Allocator)
       -> flat_multimap<Key, T>;
 }
 \end{codeblock}


### PR DESCRIPTION
Two commits here: one for `flat_{multi,}set` and then one for `flat_{multi,}map`.