### PR TITLE
Eliminate some flat_map and flat_set deduction guides which are nonsensical

### DIFF
--- a/source/containers.tex
+++ b/source/containers.tex
@@ -10779,10 +10779,6 @@ namespace std {
                   less<typename KeyContainer::value_type>,
                   KeyContainer, MappedContainer>;
 
-  template <class Container, class Alloc>
-    flat_map(Container, Alloc)
-      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>>;
-
   template <class KeyContainer, class MappedContainer, class Alloc>
     flat_map(KeyContainer, MappedContainer, Alloc)
       -> flat_map<typename KeyContainer::value_type,
@@ -10801,10 +10797,6 @@ namespace std {
                   less<typename KeyContainer::value_type>,
                   KeyContainer, MappedContainer>;
 
-  template <class Container, class Alloc>
-    flat_map(sorted_unique_t, Container, Alloc)
-      -> flat_map<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>>;
-
   template <class KeyContainer, class MappedContainer, class Alloc>
     flat_map(sorted_unique_t, KeyContainer, MappedContainer, Alloc)
       -> flat_map<typename KeyContainer::value_type,
@@ -10816,49 +10808,17 @@ namespace std {
     flat_map(InputIterator, InputIterator, Compare = Compare())
       -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Compare, class Alloc>
-    flat_map(InputIterator, InputIterator, Compare, Alloc)
-      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
-
-  template<class InputIterator, class Alloc>
-    flat_map(InputIterator, InputIterator, Alloc)
-      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>>;
-
   template <class InputIterator, class Compare = less<@\placeholder{iter-mapped-type}@<InputIterator>>>
     flat_map(sorted_unique_t, InputIterator, InputIterator, Compare = Compare())
       -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
-
-  template<class InputIterator, class Compare, class Alloc>
-    flat_map(sorted_unique_t, InputIterator, InputIterator, Compare, Alloc)
-      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
-
-  template<class InputIterator, class Alloc>
-    flat_map(sorted_unique_t, InputIterator, InputIterator, Alloc)
-      -> flat_map<@\placeholder{iter-mapped-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>>;
 
   template<class Key, class T, class Compare = less<Key>>
     flat_map(initializer_list<pair<Key, T>>, Compare = Compare())
       -> flat_map<Key, T, Compare>;
 
-  template<class Key, class T, class Compare, class Alloc>
-    flat_map(initializer_list<pair<Key, T>>, Compare, Alloc)
-      -> flat_map<Key, T, Compare>;
-
-  template<class Key, class T, class Alloc>
-    flat_map(initializer_list<pair<Key, T>>, Alloc)
-      -> flat_map<Key, T>;
-
   template<class Key, class T, class Compare = less<Key>>
   flat_map(sorted_unique_t, initializer_list<pair<Key, T>>, Compare = Compare())
       -> flat_map<Key, T, Compare>;
-
-  template<class Key, class T, class Compare, class Alloc>
-    flat_map(sorted_unique_t, initializer_list<pair<Key, T>>, Compare, Alloc)
-      -> flat_map<Key, T, Compare>;
-
-  template<class Key, class T, class Alloc>
-    flat_map(sorted_unique_t, initializer_list<pair<Key, T>>, Alloc)
-      -> flat_map<Key, T>;
 }
 \end{codeblock}
 
@@ -11776,10 +11736,6 @@ namespace std {
                        less<typename KeyContainer::value_type>,
                        KeyContainer, MappedContainer>;
 
-  template <class Container, class Alloc>
-    flat_multimap(Container, Alloc)
-      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>>;
-
   template <class KeyContainer, class MappedContainer, class Alloc>
     flat_multimap(KeyContainer, MappedContainer, Alloc)
       -> flat_multimap<typename KeyContainer::value_type,
@@ -11798,10 +11754,6 @@ namespace std {
                        less<typename KeyContainer::value_type>,
                        KeyContainer, MappedContainer>;
 
-  template <class Container, class Alloc>
-    flat_multimap(sorted_equivalent_t, Container, Alloc)
-      -> flat_multimap<@\placeholder{cont-key-type}@<Container>, @\placeholder{cont-mapped-type}@<Container>>;
-
   template <class KeyContainer, class MappedContainer, class Alloc>
     flat_multimap(sorted_equivalent_t, KeyContainer, MappedContainer, Alloc)
       -> flat_multimap<typename KeyContainer::value_type,
@@ -11813,51 +11765,19 @@ namespace std {
     flat_multimap(InputIterator, InputIterator, Compare = Compare())
       -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Compare, class Alloc>
-    flat_multimap(InputIterator, InputIterator, Compare, Alloc)
-      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
-
-  template<class InputIterator, class Alloc>
-    flat_multimap(InputIterator, InputIterator, Alloc)
-      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>>;
-
   template <class InputIterator, class Compare = less<@\placeholder{iter-key-type}@<InputIterator>>>
     flat_multimap(sorted_equivalent_t, InputIterator, InputIterator,
                   Compare = Compare())
       -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Compare, class Alloc>
-    flat_multimap(sorted_equivalent_t, InputIterator, InputIterator, Compare, Alloc)
-      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>, Compare>;
-
-  template<class InputIterator, class Alloc>
-    flat_multimap(sorted_equivalent_t, InputIterator, InputIterator, Alloc)
-      -> flat_multimap<@\placeholder{iter-key-type}@<InputIterator>, @\placeholder{iter-mapped-type}@<InputIterator>>;
-
   template<class Key, class T, class Compare = less<Key>>
     flat_multimap(initializer_list<pair<Key, T>>, Compare = Compare())
       -> flat_multimap<Key, T, Compare>;
-
-  template<class Key, class T, class Compare, class Alloc>
-    flat_multimap(initializer_list<pair<Key, T>>, Compare, Alloc)
-      -> flat_multimap<Key, T, Compare>;
-
-  template<class Key, class T, class Alloc>
-    flat_multimap(initializer_list<pair<Key, T>>, Alloc)
-      -> flat_multimap<Key, T>;
 
   template<class Key, class T, class Compare = less<Key>>
   flat_multimap(sorted_equivalent_t, initializer_list<pair<Key, T>>,
                 Compare = Compare())
       -> flat_multimap<Key, T, Compare>;
-
-  template<class Key, class T, class Compare, class Alloc>
-    flat_multimap(sorted_equivalent_t, initializer_list<pair<Key, T>>, Compare, Alloc)
-      -> flat_multimap<Key, T, Compare>;
-
-  template<class Key, class T, class Alloc>
-    flat_multimap(sorted_equivalent_t, initializer_list<pair<Key, T>>, Alloc)
-      -> flat_multimap<Key, T>;
 }
 \end{codeblock}
 
@@ -12542,65 +12462,25 @@ namespace std {
     flat_set(Container)
       -> flat_set<@\placeholder{cont-value-type}@<Container>>;
 
-  template <class Container, class Alloc>
-    flat_set(Container, Alloc)
-      -> flat_set<@\placeholder{cont-value-type}@<Container>>;
-
   template <class Container>
     flat_set(sorted_unique_t, Container)
-      -> flat_set<@\placeholder{cont-value-type}@<Container>>;
-
-  template <class Container, class Alloc>
-    flat_set(sorted_unique_t, Container, Alloc)
       -> flat_set<@\placeholder{cont-value-type}@<Container>>;
 
   template <class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
     flat_set(InputIterator, InputIterator, Compare = Compare())
       -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Compare, class Alloc>
-    flat_set(InputIterator, InputIterator, Compare, Alloc)
-      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare>;
-
-  template<class InputIterator, class Alloc>
-    flat_set(InputIterator, InputIterator, Alloc)
-      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>>;
-
   template <class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
     flat_set(sorted_unique_t, InputIterator, InputIterator, Compare = Compare())
       -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare>;
-
-  template<class InputIterator, class Compare, class Alloc>
-    flat_set(sorted_unique_t, InputIterator, InputIterator, Compare, Alloc)
-      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>, Compare>;
-
-  template<class InputIterator, class Alloc>
-    flat_set(sorted_unique_t, InputIterator, InputIterator, Alloc)
-      -> flat_set<@\placeholder{iter-value-type}@<InputIterator>>;
 
   template<class Key, class Compare = less<Key>>
     flat_set(initializer_list<Key>, Compare = Compare())
       -> flat_set<Key, Compare>;
 
-  template<class Key, class Compare, class Alloc>
-    flat_set(initializer_list<Key>, Compare, Alloc)
-      -> flat_set<Key, Compare>;
-
-  template<class Key, class Alloc>
-    flat_set(initializer_list<Key>, Alloc)
-      -> flat_set<Key>;
-
   template<class Key, class Compare = less<Key>>
     flat_set(sorted_unique_t, initializer_list<Key>, Compare = Compare())
       -> flat_set<Key, Compare>;
-
-  template<class Key, class Compare, class Alloc>
-    flat_set(sorted_unique_t, initializer_list<Key>, Compare, Alloc)
-      -> flat_set<Key, Compare>;
-
-  template<class Key, class Alloc>
-    flat_set(sorted_unique_t, initializer_list<Key>, Alloc)
-      -> flat_set<Key>;
 }
 \end{codeblock}
 
@@ -13205,65 +13085,25 @@ class flat_multiset {
     flat_multiset(Container)
       -> flat_multiset<@\placeholder{cont-value-type}@<Container>>;
 
-  template <class Container, class Alloc>
-    flat_multiset(Container, Alloc)
-      -> flat_multiset<@\placeholder{cont-value-type}@<Container>>;
-
   template <class Container>
     flat_multiset(sorted_equivalent_t, Container)
-      -> flat_multiset<@\placeholder{cont-value-type}@<Container>>;
-
-  template <class Container, class Alloc>
-    flat_multiset(sorted_equivalent_t, Container, Alloc)
       -> flat_multiset<@\placeholder{cont-value-type}@<Container>>;
 
   template <class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
     flat_multiset(InputIterator, InputIterator, Compare = Compare())
       -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare>;
 
-  template<class InputIterator, class Compare, class Alloc>
-    flat_multiset(InputIterator, InputIterator, Compare, Alloc)
-      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare>;
-
-  template<class InputIterator, class Alloc>
-    flat_multiset(InputIterator, InputIterator, Alloc)
-      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>>;
-
   template <class InputIterator, class Compare = less<@\placeholder{iter-value-type}@<InputIterator>>>
     flat_multiset(sorted_equivalent_t, InputIterator, InputIterator, Compare = Compare())
       -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare>;
-
-  template<class InputIterator, class Compare, class Alloc>
-    flat_multiset(sorted_equivalent_t, InputIterator, InputIterator, Compare, Alloc)
-      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>, Compare>;
-
-  template<class InputIterator, class Alloc>
-    flat_multiset(sorted_equivalent_t, InputIterator, InputIterator, Alloc)
-      -> flat_multiset<@\placeholder{iter-value-type}@<InputIterator>, @\placeholder{iter-value-type}@<InputIterator>>;
 
   template<class Key, class Compare = less<Key>>
     flat_multiset(initializer_list<Key>, Compare = Compare())
       -> flat_multiset<Key, Compare>;
 
-  template<class Key, class Compare, class Alloc>
-    flat_multiset(initializer_list<Key>, Compare, Alloc)
-      -> flat_multiset<Key, Compare>;
-
-  template<class Key, class Alloc>
-    flat_multiset(initializer_list<Key>, Alloc)
-      -> flat_multiset<Key>;
-
   template<class Key, class Compare = less<Key>>
   flat_multiset(sorted_equivalent_t, initializer_list<Key>, Compare = Compare())
       -> flat_multiset<Key, Compare>;
-
-  template<class Key, class Compare, class Alloc>
-    flat_multiset(sorted_equivalent_t, initializer_list<Key>, Compare, Alloc)
-      -> flat_multiset<Key, Compare>;
-
-  template<class Key, class Alloc>
-  flat_multiset(sorted_equivalent_t, initializer_list<Key>, Alloc)
-      -> flat_multiset<Key>;
 }
 \end{codeblock}
 


### PR DESCRIPTION
Consider the CTAD for `flat_set(initializer_list<int>, Alloc)`. It deduces `flat_set<int>`,
so the underlying container is `vector<int>`, which means the `Alloc` parameter will be
ill-formed unless it is _exactly_ `std::allocator<int>()`, which is pointless.
It is bad to have a deduction guide which is literally never used except in a pathological case.

In some of the `flat_{multi,}set` cases, it would actually make sense to keep
the deduction guide, but change what gets deduced, to match up better with `flat_map`.
For example,

    std::pmr::vector<int> vs;
    auto fs = flat_set(vs);
    auto fm = flat_map(vs, vs);

currently deduces

    flat_set<int, std::less<int>, std::vector<int>> fs;
    flat_set<int, int, std::less<int>, std::pmr::vector<int>, std::pmr::vector<int>> fm;

If `flat_set(vs)` were changed to deduce `flat_set<int, std::less<int>, std::pmr::vector<int>>`
in this case, then it would make sense to keep `flat_set(vs, alloc)`.


TLDR: any deduction guide which has a deduced function parameter `Alloc` but no deduced function parameter `{Key,Mapped,}Container` is pathological and should be dropped.